### PR TITLE
Fix broken access control on saveCityGuideAction

### DIFF
--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -1,0 +1,60 @@
+import { saveCityGuideAction } from '@/app/actions';
+import { getServerSession } from 'next-auth';
+import TravelGuideService from '@/lib/TravelGuideService';
+
+// Keep these heavy/server-only modules out of the unit test.
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }));
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+jest.mock('@/lib/auth', () => ({ authOptions: {} }));
+jest.mock('@/lib/FlightBookingService', () =>
+    jest.fn().mockImplementation(() => ({ bookFlight: jest.fn() }))
+);
+
+// The service mock shares a single saveCityGuide fn across all instances,
+// so the instance created inside app/actions.ts uses the same spy we assert on.
+jest.mock('@/lib/TravelGuideService', () => {
+    const saveCityGuide = jest.fn();
+    return jest.fn().mockImplementation(() => ({ saveCityGuide }));
+});
+
+jest.mock('@/lib/prisma', () => ({
+    prisma: { cityGuide: { create: jest.fn(), delete: jest.fn() } },
+}));
+
+const mockedGetServerSession = getServerSession as unknown as jest.Mock;
+const mockSaveCityGuide = new (TravelGuideService as any)().saveCityGuide as jest.Mock;
+
+const sampleGuide: any = {
+    city: 'Paris',
+    country: 'France',
+    latlong: [48.85, 2.35],
+    description: 'City of light',
+    highlights: ['Eiffel Tower'],
+    coverImage: null,
+};
+
+describe('saveCityGuideAction authorization', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('rejects an unauthenticated user', async () => {
+        mockedGetServerSession.mockResolvedValue(null);
+        await expect(saveCityGuideAction(sampleGuide)).rejects.toThrow('Unauthorized');
+        expect(mockSaveCityGuide).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-admin user', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { role: 'USER' } });
+        await expect(saveCityGuideAction(sampleGuide)).rejects.toThrow('Unauthorized');
+        expect(mockSaveCityGuide).not.toHaveBeenCalled();
+    });
+
+    it('allows an admin user and saves the guide', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+        mockSaveCityGuide.mockResolvedValue({ ...sampleGuide, id: 1 });
+
+        const result = await saveCityGuideAction(sampleGuide);
+
+        expect(mockSaveCityGuide).toHaveBeenCalledWith(sampleGuide);
+        expect(result).toHaveProperty('id', 1);
+    });
+});

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -12,6 +12,9 @@ const travelGuideService = new TravelGuideService();
 const flightBookingService = new FlightBookingService();
 
 export async function saveCityGuideAction(cityGuide: CityGuide) {
+    const session = await getServerSession(authOptions);
+    if ((session?.user as any)?.role !== 'ADMIN') throw new Error("Unauthorized");
+
     const result = await travelGuideService.saveCityGuide(cityGuide);
     revalidatePath('/admin/travelguide');
     revalidatePath('/travelguide');


### PR DESCRIPTION
## Problem

`saveCityGuideAction` created/updated city guides with **no authorization check**, while its sibling `deleteCityGuideAction` correctly required an `ADMIN` role. Server actions compile to callable POST endpoints, so any caller — including non-admins — could create city-guide content.

## Fix

Add the same ADMIN guard `deleteCityGuideAction` already uses:

```ts
const session = await getServerSession(authOptions);
if ((session?.user as any)?.role !== 'ADMIN') throw new Error("Unauthorized");
```

## Tests (TDD)

Added `__tests__/app/actions.test.ts` covering:
- unauthenticated user → throws `Unauthorized`, save not called
- non-admin (`USER`) → throws `Unauthorized`, save not called
- admin → save proceeds

Written test-first: confirmed red against the unguarded code, green after the fix.

## Notes
- First item of the Phase 1 (bugs & security) hardening pass.
- Two **pre-existing** test suites (`tests/admin-travelguide.test.js`, `__tests__/components/flightBookingForm.test.tsx`) fail on `main` due to an unrelated ESM/`openid-client` import issue — out of scope here, tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)