### PR TITLE
Stop register endpoint leaking password hash; add validation

### DIFF
--- a/__tests__/app/api/register.test.ts
+++ b/__tests__/app/api/register.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment node */
+import { POST } from '@/app/api/auth/register/route';
+import { prisma } from '@/lib/prisma';
+
+jest.mock('@/lib/prisma', () => ({
+    prisma: { user: { findUnique: jest.fn(), create: jest.fn() } },
+}));
+jest.mock('bcryptjs', () => ({ hash: jest.fn().mockResolvedValue('hashed-pw') }));
+
+const mockedPrisma = prisma as unknown as {
+    user: { findUnique: jest.Mock; create: jest.Mock };
+};
+
+// The handler only calls req.json(); a minimal stub is enough.
+const makeReq = (body: unknown) => ({ json: async () => body }) as any;
+
+describe('POST /api/auth/register', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('never returns the password hash on success', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue(null);
+        mockedPrisma.user.create.mockResolvedValue({
+            id: 'u1',
+            name: 'Ada',
+            email: 'ada@example.com',
+            password: 'hashed-pw',
+            role: 'USER',
+        });
+
+        const res = await POST(makeReq({ name: 'Ada', email: 'ada@example.com', password: 'password123' }));
+        expect(res.status).toBe(201);
+
+        const data = await res.json();
+        expect(data.user).toBeDefined();
+        expect(data.user.password).toBeUndefined();
+        expect(data.user).toMatchObject({ id: 'u1', email: 'ada@example.com' });
+    });
+
+    it('rejects an invalid email', async () => {
+        const res = await POST(makeReq({ name: 'Ada', email: 'not-an-email', password: 'password123' }));
+        expect(res.status).toBe(400);
+        expect(mockedPrisma.user.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a too-short password', async () => {
+        const res = await POST(makeReq({ name: 'Ada', email: 'ada@example.com', password: 'short' }));
+        expect(res.status).toBe(400);
+        expect(mockedPrisma.user.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects missing fields', async () => {
+        const res = await POST(makeReq({ email: 'ada@example.com' }));
+        expect(res.status).toBe(400);
+        expect(mockedPrisma.user.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a duplicate user', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue({ id: 'existing' });
+        const res = await POST(makeReq({ name: 'Ada', email: 'ada@example.com', password: 'password123' }));
+        expect(res.status).toBe(400);
+        expect(mockedPrisma.user.create).not.toHaveBeenCalled();
+    });
+});

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -2,12 +2,26 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import bcrypt from 'bcryptjs';
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LENGTH = 8;
+
 export async function POST(req: Request) {
     try {
         const { name, email, password } = await req.json();
 
         if (!name || !email || !password) {
             return NextResponse.json({ message: 'Missing fields' }, { status: 400 });
+        }
+
+        if (typeof email !== 'string' || !EMAIL_REGEX.test(email)) {
+            return NextResponse.json({ message: 'Invalid email address' }, { status: 400 });
+        }
+
+        if (typeof password !== 'string' || password.length < MIN_PASSWORD_LENGTH) {
+            return NextResponse.json(
+                { message: `Password must be at least ${MIN_PASSWORD_LENGTH} characters` },
+                { status: 400 }
+            );
         }
 
         const existingUser = await prisma.user.findUnique({
@@ -28,8 +42,16 @@ export async function POST(req: Request) {
             },
         });
 
-        return NextResponse.json({ message: 'User registered successfully', user }, { status: 201 });
+        // Never return the password hash (or any other sensitive field) to the client.
+        const safeUser = { id: user.id, name: user.name, email: user.email, role: user.role };
+
+        return NextResponse.json(
+            { message: 'User registered successfully', user: safeUser },
+            { status: 201 }
+        );
     } catch (error) {
-        return NextResponse.json({ message: 'Error registering user', error }, { status: 500 });
+        // Log server-side; do not leak internal error details to the client.
+        console.error('Error registering user:', error);
+        return NextResponse.json({ message: 'Error registering user' }, { status: 500 });
     }
 }


### PR DESCRIPTION
## Problem
`POST /api/auth/register` returned the full created `user` object — **including the bcrypt password hash** — in its JSON response. It also had no email/password validation and echoed the raw error object on 500.

## Fix
- Return only safe fields: `{ id, name, email, role }` — never the hash
- Validate email format (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`) and password length (min 8)
- Reject non-string email/password before use
- Log the error server-side and return a generic 500 message (no internals leaked)

## Tests (TDD)
`__tests__/app/api/register.test.ts` (node env): asserts the response never contains `password`, plus invalid-email, short-password, missing-fields, and duplicate-user cases. Red before the fix, green after.

## Notes
- Phase 1 item #2.
- Same two pre-existing unrelated suites still fail on `main` (ESM/`openid-client`); untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)