### PR TITLE
Prevent user enumeration in credentials authorize

### DIFF
--- a/__tests__/lib/auth.test.ts
+++ b/__tests__/lib/auth.test.ts
@@ -1,0 +1,67 @@
+/** @jest-environment node */
+import { prisma } from '@/lib/prisma';
+import bcrypt from 'bcryptjs';
+
+// Make CredentialsProvider a pass-through so we can call the raw authorize fn.
+jest.mock('next-auth/providers/credentials', () => ({
+    __esModule: true,
+    default: (opts: any) => opts,
+}));
+jest.mock('@auth/prisma-adapter', () => ({ PrismaAdapter: () => ({}) }));
+jest.mock('@/lib/prisma', () => ({ prisma: { user: { findUnique: jest.fn() } } }));
+jest.mock('bcryptjs', () => ({ compare: jest.fn() }));
+
+// Imported after mocks so the mocked deps are wired in.
+import { authOptions } from '@/lib/auth';
+
+const authorize = (authOptions.providers[0] as any).authorize as (
+    credentials: Record<string, string> | undefined
+) => Promise<any>;
+
+const mockedPrisma = prisma as unknown as { user: { findUnique: jest.Mock } };
+const mockedCompare = bcrypt.compare as unknown as jest.Mock;
+
+describe('authOptions credential authorize', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('returns the same generic error for unknown user and wrong password (no enumeration)', async () => {
+        // Unknown user
+        mockedPrisma.user.findUnique.mockResolvedValue(null);
+        mockedCompare.mockResolvedValue(false);
+        const unknownErr = await authorize({ email: 'nobody@example.com', password: 'whatever12' }).catch((e) => e);
+
+        // Known user, wrong password
+        mockedPrisma.user.findUnique.mockResolvedValue({
+            id: 'u1', email: 'a@b.com', password: 'real-hash', role: 'USER',
+        });
+        mockedCompare.mockResolvedValue(false);
+        const wrongPwErr = await authorize({ email: 'a@b.com', password: 'whatever12' }).catch((e) => e);
+
+        expect(unknownErr).toBeInstanceOf(Error);
+        expect(wrongPwErr).toBeInstanceOf(Error);
+        // The core anti-enumeration property: identical messages.
+        expect(unknownErr.message).toBe(wrongPwErr.message);
+        // And not the old leaky messages.
+        expect(unknownErr.message).not.toBe('User not found');
+        expect(wrongPwErr.message).not.toBe('Invalid password');
+    });
+
+    it('always runs a bcrypt comparison even when the user does not exist (timing safety)', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue(null);
+        mockedCompare.mockResolvedValue(false);
+        await authorize({ email: 'nobody@example.com', password: 'whatever12' }).catch(() => {});
+        expect(mockedCompare).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not return the password hash on a valid login', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue({
+            id: 'u1', email: 'a@b.com', name: 'Ada', image: null, password: 'real-hash', role: 'USER',
+        });
+        mockedCompare.mockResolvedValue(true);
+
+        const result = await authorize({ email: 'a@b.com', password: 'correct-horse' });
+
+        expect(result).toMatchObject({ id: 'u1', email: 'a@b.com', role: 'USER' });
+        expect(result.password).toBeUndefined();
+    });
+});

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,6 +4,11 @@ import { PrismaAdapter } from '@auth/prisma-adapter';
 import { prisma } from '@/lib/prisma';
 import bcrypt from 'bcryptjs';
 
+// A valid bcrypt hash of a throwaway value, used only to equalize response
+// timing when no matching user exists (anti-enumeration). It is never a real
+// credential and never matches any user-supplied password.
+const DUMMY_PASSWORD_HASH = '$2b$10$m5cSUIfLL/USdiPzCLh47OC6nV84HHx2LHbBgT2c8Kw.YOCKKxBtS';
+
 export const authOptions: NextAuthOptions = {
     adapter: PrismaAdapter(prisma) as any,
     providers: [
@@ -14,25 +19,36 @@ export const authOptions: NextAuthOptions = {
                 password: { label: 'Password', type: 'password' },
             },
             async authorize(credentials) {
+                // Single generic message for every failure mode so the response
+                // never reveals whether an account with this email exists.
+                const INVALID = 'Invalid email or password';
+
                 if (!credentials?.email || !credentials?.password) {
-                    throw new Error('Invalid credentials');
+                    throw new Error(INVALID);
                 }
 
                 const user = await prisma.user.findUnique({
                     where: { email: credentials.email },
                 });
 
-                if (!user || !user.password) {
-                    throw new Error('User not found');
+                // Always run a bcrypt comparison — against the real hash when the
+                // user exists, otherwise a dummy — so response time does not leak
+                // account existence (timing-based enumeration).
+                const passwordHash = user?.password ?? DUMMY_PASSWORD_HASH;
+                const isPasswordValid = await bcrypt.compare(credentials.password, passwordHash);
+
+                if (!user || !user.password || !isPasswordValid) {
+                    throw new Error(INVALID);
                 }
 
-                const isPasswordValid = await bcrypt.compare(credentials.password, user.password);
-
-                if (!isPasswordValid) {
-                    throw new Error('Invalid password');
-                }
-
-                return user;
+                // Return only non-sensitive fields (never the password hash).
+                return {
+                    id: user.id,
+                    email: user.email,
+                    name: user.name,
+                    image: user.image,
+                    role: user.role,
+                };
             },
         }),
     ],


### PR DESCRIPTION
## Problem
The NextAuth credentials `authorize()` threw **distinct** errors — `User not found` vs `Invalid password` — so an attacker could enumerate which emails have accounts. It also returned the full Prisma `user` object (including the bcrypt `password` hash) from `authorize`.

## Fix
- One generic message (`Invalid email or password`) for all failure paths (missing creds, unknown user, OAuth-only account, wrong password)
- **Always** run a `bcrypt.compare` — against the real hash or a dummy hash — so response timing doesn't reveal account existence
- Return only non-sensitive fields: `{ id, email, name, image, role }`

## Tests (TDD)
`__tests__/lib/auth.test.ts`: identical error message for unknown-user vs wrong-password, bcrypt always invoked even when the user is absent, and no password hash in the returned user. Red before, green after.

## Notes
- Phase 1 item #3.
- Same two pre-existing unrelated suites still fail on `main`; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)