### PR TITLE
Re-enable type/lint checks and add CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,10 @@
 {
-  "extends": ["next/core-web-vitals", "next/typescript"]
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "args": "none", "varsIgnorePattern": "^_", "caughtErrors": "none" }
+    ]
+  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: npm test

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -1,5 +1,5 @@
 import FlightBookingForm from "@/components/ui/flightBookingForm";
-import React, { useEffect } from 'react';
+import React from 'react';
 
 export default function Home() {
   return (

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -2,11 +2,6 @@
 
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
-import {
-  NameType,
-  Payload,
-  ValueType,
-} from "recharts/types/component/DefaultTooltipContent"
 
 import { cn } from "@/lib/utils"
 

--- a/components/ui/charts/nextStatusChart.tsx
+++ b/components/ui/charts/nextStatusChart.tsx
@@ -1,15 +1,10 @@
 "use client"
 
 import * as React from "react"
-import { TrendingUp } from "lucide-react"
 import { Label, Pie, PieChart } from "recharts"
 
 import {
-  Card,
   CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
 } from "@/components/ui/card"
 import {
   ChartConfig,

--- a/components/ui/flightBookingForm.tsx
+++ b/components/ui/flightBookingForm.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from 'react'
-import { Suspense, useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { bookFlightAction, searchFlightsAction } from '@/app/actions'
 

--- a/components/ui/pointsActivityTable.tsx
+++ b/components/ui/pointsActivityTable.tsx
@@ -30,7 +30,6 @@ const columns = [
 
 const PointsActivityTable: React.FC<{ activityData: PointsActivityDisplayData[] }> = ({ activityData }) => {
   const [data, _setData] = React.useState(() => [...activityData])
-  const rerender = React.useReducer(() => ({}), {})[1]
 
   const table = useReactTable({
     data,

--- a/components/ui/titlebar.tsx
+++ b/components/ui/titlebar.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useSession, signIn, signOut } from 'next-auth/react';
+import { useSession, signOut } from 'next-auth/react';
 
 const TitleBar: React.FC = () => {
     const pathname = usePathname();

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    eslint: {
-        ignoreDuringBuilds: true,
-    },
-    typescript: {
-        ignoreBuildErrors: true,
-    },
     output: 'standalone',
 };
 


### PR DESCRIPTION
## Problem
Production builds silently ignored **all** TypeScript and ESLint errors via `next.config.mjs` (`typescript.ignoreBuildErrors`, `eslint.ignoreDuringBuilds`). That's how the Booking schema drift (and other issues) went unnoticed. There was also no CI gate.

## Changes
- **next.config.mjs**: removed both ignore flags — production builds now enforce TS + ESLint.
- **Dead code**: removed unused imports surfaced by lint (chart, nextStatusChart, titlebar, book page, flightBookingForm, pointsActivityTable).
- **.eslintrc.json**: `no-explicit-any` → `warn` (remaining casts are deliberate NextAuth/session typing — a proper type-augmentation follow-up will remove them); `no-unused-vars` stays an error but ignores function args, `^_`-prefixed vars, and caught errors.
- **CI** (`.github/workflows/ci.yml`): on every push/PR to `main` — `npm ci` → `prisma generate` → `npm run lint` → `tsc --noEmit` → `npm test`. Deliberately avoids `next build` (would need a DB).

## Verification (local)
- `npm run lint` → **0 errors**, 22 warnings
- `npx tsc --noEmit` → **0 errors**
- `npm test` → **23 passing, 8 suites**

This is the final Phase 1 (bugs & security) item. CI will now keep the suite + types honest going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)