### PR TITLE
Add NextAuth type augmentation; drop session/JWT `as any` casts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": ["next/core-web-vitals", "next/typescript"],
   "rules": {
-    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-unused-vars": [
       "error",
       { "args": "none", "varsIgnorePattern": "^_", "caughtErrors": "none" }

--- a/__tests__/lib/auth.test.ts
+++ b/__tests__/lib/auth.test.ts
@@ -65,3 +65,29 @@ describe('authOptions credential authorize', () => {
         expect(result.password).toBeUndefined();
     });
 });
+
+describe('authOptions jwt/session callbacks', () => {
+    const jwt = (authOptions.callbacks!.jwt as any);
+    const session = (authOptions.callbacks!.session as any);
+
+    it('jwt callback copies id and role from user onto the token', async () => {
+        const token = await jwt({
+            token: {},
+            user: { id: 'u1', role: 'ADMIN' },
+        });
+        expect(token).toMatchObject({ id: 'u1', role: 'ADMIN' });
+    });
+
+    it('jwt callback leaves the token unchanged when there is no user', async () => {
+        const token = await jwt({ token: { id: 'existing', role: 'USER' } });
+        expect(token).toMatchObject({ id: 'existing', role: 'USER' });
+    });
+
+    it('session callback exposes id and role on session.user', async () => {
+        const result = await session({
+            session: { user: { email: 'a@b.com' } },
+            token: { id: 'u1', role: 'ADMIN' },
+        });
+        expect(result.user).toMatchObject({ id: 'u1', role: 'ADMIN', email: 'a@b.com' });
+    });
+});

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -13,7 +13,7 @@ const flightBookingService = new FlightBookingService();
 
 export async function saveCityGuideAction(cityGuide: CityGuide) {
     const session = await getServerSession(authOptions);
-    if ((session?.user as any)?.role !== 'ADMIN') throw new Error("Unauthorized");
+    if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
 
     const result = await travelGuideService.saveCityGuide(cityGuide);
     revalidatePath('/admin/travelguide');
@@ -23,7 +23,7 @@ export async function saveCityGuideAction(cityGuide: CityGuide) {
 
 export async function deleteCityGuideAction(cityGuideId: number) {
     const session = await getServerSession(authOptions);
-    if ((session?.user as any)?.role !== 'ADMIN') throw new Error("Unauthorized");
+    if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
 
     await prisma.cityGuide.delete({
         where: { id: cityGuideId }
@@ -39,7 +39,7 @@ export async function searchFlightsAction(from: string, to: string) {
 
 export async function bookFlightAction(bookingData: { flightId?: number }) {
     const session = await getServerSession(authOptions);
-    const userId = session?.user ? (session.user as any).id : undefined;
+    const userId = session?.user?.id;
 
     return await flightBookingService.bookFlight({
         flightId: bookingData.flightId,
@@ -49,7 +49,7 @@ export async function bookFlightAction(bookingData: { flightId?: number }) {
 
 export async function toggleFavoriteCityGuideAction(cityGuideId: number) {
     const session = await getServerSession(authOptions);
-    const userId = session?.user ? (session.user as any).id : undefined;
+    const userId = session?.user?.id;
     if (!userId) throw new Error("Unauthorized");
 
     const existing = await prisma.userFavorite.findUnique({
@@ -71,7 +71,7 @@ export async function toggleFavoriteCityGuideAction(cityGuideId: number) {
 
 export async function submitCityGuideReviewAction(cityGuideId: number, rating: number, content: string) {
     const session = await getServerSession(authOptions);
-    const userId = session?.user ? (session.user as any).id : undefined;
+    const userId = session?.user?.id;
     if (!userId) throw new Error("Unauthorized");
 
     return await prisma.review.create({

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -15,7 +15,7 @@ export default async function Home() {
   }
 
   const user = session.user;
-  const userId = (user as any).id;
+  const userId = user.id;
   const userName = user.name || "Traveler";
   const userAvatar = user.image || "https://i.pravatar.cc/150?u=" + userId;
 

--- a/app/travelguide/page.tsx
+++ b/app/travelguide/page.tsx
@@ -6,7 +6,7 @@ import { authOptions } from '@/lib/auth';
 
 export default async function TravelGuidePage() {
     const session = await getServerSession(authOptions);
-    const userId = session?.user ? (session.user as any).id : null;
+    const userId = session?.user?.id ?? null;
 
     const cities = await prisma.cityGuide.findMany({
         include: { reviews: { include: { user: true } } }
@@ -22,5 +22,5 @@ export default async function TravelGuidePage() {
         initialFavorites = favs.map((f: { cityGuideId: number }) => f.cityGuideId);
     }
 
-    return <TravelGuideClient cities={cities as any} initialFavorites={initialFavorites} />;
+    return <TravelGuideClient cities={cities} initialFavorites={initialFavorites} />;
 }

--- a/components/ui/TravelGuideClient.tsx
+++ b/components/ui/TravelGuideClient.tsx
@@ -71,7 +71,7 @@ export default function TravelGuideClient({ cities, initialFavorites }: { cities
                 <Suspense fallback={<div>Loading Map...</div>}>
                     <ComposableMap projection="geoEqualEarth" projectionConfig={{ scale: 600, center: [-70, 28] }} style={{ maxHeight: "1400" }} preserveAspectRatio="none" viewBox="0 0 800 500">
                         <Geographies geography="/map.json">
-                            {({ geographies }: { geographies: any[] }) => geographies.map((geo) => (
+                            {({ geographies }: { geographies: Array<{ rsmKey: string }> }) => geographies.map((geo) => (
                                 <Geography key={geo.rsmKey} geography={geo} fill="#444" stroke="#1F2328" />
                             ))}
                         </Geographies>

--- a/components/ui/charts/pointsHistoryChart.tsx
+++ b/components/ui/charts/pointsHistoryChart.tsx
@@ -17,6 +17,7 @@ import {
     ChartTooltipContent,
 } from "@/components/ui/chart"
 import PointsActivityService from "@/lib/PointsActivityService"
+import { PointsActivityDisplayData } from "@/lib/types/PointsActivity"
 
 const chartConfig = {
     points: {
@@ -26,7 +27,7 @@ const chartConfig = {
 } satisfies ChartConfig
 
 export default function PointsHistoryChart() {
-    const [chartData, setChartData] = React.useState<any[]>([])
+    const [chartData, setChartData] = React.useState<PointsActivityDisplayData[]>([])
 
     React.useEffect(() => {
         const service = new PointsActivityService()

--- a/components/ui/flightBookingForm.tsx
+++ b/components/ui/flightBookingForm.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { bookFlightAction, searchFlightsAction } from '@/app/actions'
+import { Flight } from '@prisma/client'
 
 const FlightBookingForm: React.FC = () => {
     const [departureDate, setDepartureDate] = useState<string>('');
@@ -13,7 +14,7 @@ const FlightBookingForm: React.FC = () => {
     const [flightClass, setFlightClass] = useState('economy');
     const [isOneWay, setIsOneWay] = useState(false);
     const [isSearching, setIsSearching] = useState(false);
-    const [searchResults, setSearchResults] = useState<any[] | null>(null);
+    const [searchResults, setSearchResults] = useState<Flight[] | null>(null);
     const [bookingState, setBookingState] = useState<{ status: 'idle' | 'booking' | 'success' | 'error', message?: string, flightId?: number }>({ status: 'idle' });
 
     const handleTripTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -39,7 +40,7 @@ const FlightBookingForm: React.FC = () => {
         }
     };
 
-    const handleBookFlight = async (flight: any) => {
+    const handleBookFlight = async (flight: Flight) => {
         setBookingState({ status: 'booking', flightId: flight.id });
         try {
             await bookFlightAction({ flightId: flight.id });

--- a/components/ui/titlebar.tsx
+++ b/components/ui/titlebar.tsx
@@ -19,7 +19,7 @@ const TitleBar: React.FC = () => {
 
     const pageTitle = pageTitles[pathname] || '';
     const userAvatar = session?.user?.image || "/img/my-profile-photo.jpg";
-    const isAdmin = (session?.user as any)?.role === 'ADMIN';
+    const isAdmin = session?.user?.role === 'ADMIN';
 
     return (
         <header className={pathname?.startsWith('/admin') ? 'admin-header' : ''}>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,5 @@
 import { NextAuthOptions } from 'next-auth';
+import { Adapter } from 'next-auth/adapters';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { PrismaAdapter } from '@auth/prisma-adapter';
 import { prisma } from '@/lib/prisma';
@@ -10,7 +11,9 @@ import bcrypt from 'bcryptjs';
 const DUMMY_PASSWORD_HASH = '$2b$10$m5cSUIfLL/USdiPzCLh47OC6nV84HHx2LHbBgT2c8Kw.YOCKKxBtS';
 
 export const authOptions: NextAuthOptions = {
-    adapter: PrismaAdapter(prisma) as any,
+    // @auth/prisma-adapter is typed against @auth/core's Adapter, which is
+    // structurally compatible with next-auth v4's Adapter but nominally distinct.
+    adapter: PrismaAdapter(prisma) as Adapter,
     providers: [
         CredentialsProvider({
             name: 'Credentials',
@@ -63,14 +66,14 @@ export const authOptions: NextAuthOptions = {
         async jwt({ token, user, account }) {
             if (user) {
                 token.id = user.id;
-                token.role = (user as any).role;
+                token.role = user.role;
             }
             return token;
         },
         async session({ session, token }) {
             if (session.user) {
-                (session.user as any).id = token.id as string;
-                (session.user as any).role = token.role as string;
+                session.user.id = token.id;
+                session.user.role = token.role;
             }
             return session;
         },

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,25 @@
+// Module augmentation for NextAuth so `session.user.id` / `session.user.role`
+// and the JWT equivalents are strongly typed across the app — no `as any`.
+import { Role } from '@prisma/client';
+import { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+    interface Session {
+        user: {
+            id: string;
+            role: Role;
+        } & NonNullable<DefaultSession['user']>;
+    }
+
+    // Shape returned by the credentials `authorize` callback and passed into `jwt`.
+    interface User {
+        role: Role;
+    }
+}
+
+declare module 'next-auth/jwt' {
+    interface JWT {
+        id: string;
+        role: Role;
+    }
+}


### PR DESCRIPTION
## Summary

Adds proper NextAuth/TypeScript module augmentation so the codebase stops using `as any` to read `session.user.id` and `session.user.role`, then re-tightens `@typescript-eslint/no-explicit-any` from `"warn"` back to `"error"`.

## Changes

- **New `types/next-auth.d.ts`** augmenting:
  - `next-auth` → `Session.user` with `id` + `role`, and `User` with `role`
  - `next-auth/jwt` → `JWT` with `id` + `role`
  - `role` typed via the Prisma `Role` enum
- **Removed `as any` casts** that read `session.user.id` / `session.user.role`, relying on the augmented types instead:
  - `lib/auth.ts` (jwt/session callbacks)
  - `app/actions.ts` (5 sites)
  - `app/profile/page.tsx`, `app/travelguide/page.tsx`
  - `components/ui/titlebar.tsx`
- **Typed the remaining stray `any`s properly** (so the rule can be flipped to error):
  - Prisma `Flight` in `components/ui/flightBookingForm.tsx`
  - `PointsActivityDisplayData` in `components/ui/charts/pointsHistoryChart.tsx`
  - react-simple-maps geographies render prop in `components/ui/TravelGuideClient.tsx`
  - auth adapter cast narrowed from `as any` to `as Adapter` (from `next-auth/adapters`)
  - dropped the unnecessary `cities as any` cast in `app/travelguide/page.tsx`
- **Re-tightened** `@typescript-eslint/no-explicit-any` to `"error"` in `.eslintrc.json`.
- **Tests**: added `jwt`/`session` callback tests in `__tests__/lib/auth.test.ts` locking in id/role propagation.

## Verification

- `npm run lint` → 0 errors, 0 `no-explicit-any` warnings (only pre-existing `no-img-element` warnings remain)
- `npx tsc --noEmit` → 0 errors
- `npm test` → 26 passed, 8 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)