### PR TITLE
Make flight search real (inventory-driven, dependent routes)

### DIFF
--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -1,6 +1,7 @@
-import { saveCityGuideAction } from '@/app/actions';
+import { saveCityGuideAction, searchFlightsAction, getFlightRoutesAction } from '@/app/actions';
 import { getServerSession } from 'next-auth';
 import TravelGuideService from '@/lib/TravelGuideService';
+import { prisma } from '@/lib/prisma';
 
 // Keep these heavy/server-only modules out of the unit test.
 jest.mock('next-auth', () => ({ getServerSession: jest.fn() }));
@@ -18,11 +19,15 @@ jest.mock('@/lib/TravelGuideService', () => {
 });
 
 jest.mock('@/lib/prisma', () => ({
-    prisma: { cityGuide: { create: jest.fn(), delete: jest.fn() } },
+    prisma: {
+        cityGuide: { create: jest.fn(), delete: jest.fn() },
+        flight: { findMany: jest.fn() },
+    },
 }));
 
 const mockedGetServerSession = getServerSession as unknown as jest.Mock;
 const mockSaveCityGuide = new (TravelGuideService as any)().saveCityGuide as jest.Mock;
+const mockedFlightFindMany = (prisma as any).flight.findMany as jest.Mock;
 
 const sampleGuide: any = {
     city: 'Paris',
@@ -56,5 +61,42 @@ describe('saveCityGuideAction authorization', () => {
 
         expect(mockSaveCityGuide).toHaveBeenCalledWith(sampleGuide);
         expect(result).toHaveProperty('id', 1);
+    });
+});
+
+describe('searchFlightsAction', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('filters flights by the selected origin and destination', async () => {
+        const flights = [
+            { id: 1, flightNumber: 'CA101', from: 'Seattle, USA', to: 'Detroit, USA' },
+        ];
+        mockedFlightFindMany.mockResolvedValue(flights);
+
+        const result = await searchFlightsAction('Seattle, USA', 'Detroit, USA');
+
+        expect(mockedFlightFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { from: 'Seattle, USA', to: 'Detroit, USA' } })
+        );
+        expect(result).toBe(flights);
+    });
+});
+
+describe('getFlightRoutesAction', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('returns the distinct origin/destination pairs that have flights', async () => {
+        const routes = [
+            { from: 'Chicago, USA', to: 'Paris, France' },
+            { from: 'Seattle, USA', to: 'Detroit, USA' },
+        ];
+        mockedFlightFindMany.mockResolvedValue(routes);
+
+        const result = await getFlightRoutesAction();
+
+        expect(result).toBe(routes);
+        expect(mockedFlightFindMany).toHaveBeenCalledWith(
+            expect.objectContaining({ distinct: ['from', 'to'], select: { from: true, to: true } })
+        );
     });
 });

--- a/__tests__/components/flightBookingForm.test.tsx
+++ b/__tests__/components/flightBookingForm.test.tsx
@@ -14,49 +14,81 @@ jest.mock('@/app/actions', () => ({
 const mockSearch = searchFlightsAction as jest.Mock;
 const mockBook = bookFlightAction as jest.Mock;
 
+const routes = [
+    { from: 'Seattle, USA', to: 'Detroit, USA' },
+    { from: 'Seattle, USA', to: 'Tokyo, Japan' },
+    { from: 'New York, USA', to: 'London, UK' },
+];
+
 const mockFlights = [
     {
         id: 1,
-        flightNumber: 'MA101',
-        airline: 'Mona Air',
-        from: 'SFO',
-        to: 'NYC',
-        departureDate: '2026-03-01',
+        flightNumber: 'CA101',
+        airline: 'Gemini Airways',
+        from: 'Seattle, USA',
+        to: 'Detroit, USA',
+        departureDate: '2026-05-15',
         returnDate: null,
         price: '$350',
     },
 ];
 
+const renderForm = () => render(<FlightBookingForm routes={routes} />);
+
 describe('FlightBookingForm', () => {
     beforeEach(() => jest.clearAllMocks());
 
-    it('renders the generic search form', () => {
-        render(<FlightBookingForm />);
+    it('renders origins and the destinations reachable from the default origin', () => {
+        renderForm();
         expect(screen.getByText('Where Your Journey Takes Flight')).toBeInTheDocument();
-        expect(screen.getByLabelText('From')).toBeInTheDocument();
-        expect(screen.getByLabelText('To')).toBeInTheDocument();
-        expect(screen.getByText('Find your trip')).toBeInTheDocument();
+        // Origins (distinct departure cities)
+        expect(screen.getByRole('option', { name: 'Seattle, USA' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'New York, USA' })).toBeInTheDocument();
+        // Destinations for the default origin (Seattle)
+        expect(screen.getByRole('option', { name: 'Detroit, USA' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Tokyo, Japan' })).toBeInTheDocument();
+        // London is only reachable from New York, so it must not appear yet
+        expect(screen.queryByRole('option', { name: 'London, UK' })).not.toBeInTheDocument();
     });
 
-    it('shows the flights returned by searchFlightsAction', async () => {
+    it('updates the destination options when the origin changes', () => {
+        renderForm();
+        fireEvent.change(screen.getByLabelText('From'), { target: { value: 'New York, USA' } });
+        expect(screen.getByRole('option', { name: 'London, UK' })).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'Detroit, USA' })).not.toBeInTheDocument();
+    });
+
+    it('searches using the selected origin and destination', async () => {
         mockSearch.mockResolvedValue(mockFlights);
 
-        render(<FlightBookingForm />);
+        renderForm();
         fireEvent.click(screen.getByText('Find your trip'));
 
         await waitFor(() => {
             expect(screen.getByText('Available Flights')).toBeInTheDocument();
-            expect(screen.getByText('MA101')).toBeInTheDocument();
+            expect(screen.getByText('CA101')).toBeInTheDocument();
         });
-        // Defaults are SFO -> NYC.
-        expect(mockSearch).toHaveBeenCalledWith('SFO', 'NYC');
+        // Defaults to the first origin and its first reachable destination.
+        expect(mockSearch).toHaveBeenCalledWith('Seattle, USA', 'Detroit, USA');
+    });
+
+    it('shows a no-results message when no flights match the route', async () => {
+        mockSearch.mockResolvedValue([]);
+
+        renderForm();
+        fireEvent.click(screen.getByText('Find your trip'));
+
+        await waitFor(() => {
+            expect(screen.getByText(/No flights found/i)).toBeInTheDocument();
+        });
+        expect(screen.queryByText('Available Flights')).not.toBeInTheDocument();
     });
 
     it('books a flight via bookFlightAction when "Book Now" is clicked', async () => {
         mockSearch.mockResolvedValue(mockFlights);
         mockBook.mockResolvedValue({ id: 999 });
 
-        render(<FlightBookingForm />);
+        renderForm();
         fireEvent.click(screen.getByText('Find your trip'));
 
         await waitFor(() => expect(screen.getByText('Available Flights')).toBeInTheDocument());
@@ -66,7 +98,7 @@ describe('FlightBookingForm', () => {
         await waitFor(() => {
             expect(mockBook).toHaveBeenCalledTimes(1);
             expect(mockBook).toHaveBeenCalledWith({ flightId: 1 });
-            expect(screen.getByText(/Successfully booked flight MA101/)).toBeInTheDocument();
+            expect(screen.getByText(/Successfully booked flight CA101/)).toBeInTheDocument();
         });
     });
 });

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -33,8 +33,20 @@ export async function deleteCityGuideAction(cityGuideId: number) {
 }
 
 export async function searchFlightsAction(from: string, to: string) {
-    // Mock search by just returning all flights so users can see data regardless of selection
-    return await prisma.flight.findMany();
+    return await prisma.flight.findMany({
+        where: { from, to },
+        orderBy: { departureDate: 'asc' },
+    });
+}
+
+export async function getFlightRoutesAction() {
+    // Distinct origin/destination pairs that actually have flights, so the
+    // booking form can offer only reachable routes.
+    return await prisma.flight.findMany({
+        distinct: ['from', 'to'],
+        select: { from: true, to: true },
+        orderBy: [{ from: 'asc' }, { to: 'asc' }],
+    });
 }
 
 export async function bookFlightAction(bookingData: { flightId?: number }) {

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -1,8 +1,10 @@
 import FlightBookingForm from "@/components/ui/flightBookingForm";
 import React from 'react';
+import { getFlightRoutesAction } from "@/app/actions";
 
-export default function Home() {
+export default async function Home() {
+  const routes = await getFlightRoutesAction();
   return (
-        <FlightBookingForm />
-  )
+    <FlightBookingForm routes={routes} />
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import FlightBookingForm from "../components/ui/flightBookingForm";
+import { getFlightRoutesAction } from "./actions";
 
-export default function Home() {
+export default async function Home() {
+  const routes = await getFlightRoutesAction();
   return (
-        <FlightBookingForm />
+    <FlightBookingForm routes={routes} />
   );
 }

--- a/components/ui/flightBookingForm.tsx
+++ b/components/ui/flightBookingForm.tsx
@@ -1,16 +1,27 @@
 "use client"
 
 import * as React from 'react'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
 import { bookFlightAction, searchFlightsAction } from '@/app/actions'
 import { Flight } from '@prisma/client'
 
-const FlightBookingForm: React.FC = () => {
+interface FlightBookingFormProps {
+    routes?: { from: string; to: string }[];
+}
+
+const FlightBookingForm: React.FC<FlightBookingFormProps> = ({ routes = [] }) => {
+    // Origins are the distinct departure cities; destinations depend on the
+    // selected origin so only reachable routes can be chosen.
+    const origins = useMemo(() => Array.from(new Set(routes.map((r) => r.from))), [routes]);
+    const [fromLocation, setFromLocation] = useState(origins[0] ?? '');
+    const destinations = useMemo(
+        () => routes.filter((r) => r.from === fromLocation).map((r) => r.to),
+        [routes, fromLocation]
+    );
+    const [toLocation, setToLocation] = useState(destinations[0] ?? '');
     const [departureDate, setDepartureDate] = useState<string>('');
     const [returnDate, setReturnDate] = useState<string>('');
-    const [fromLocation, setFromLocation] = useState('SFO');
-    const [toLocation, setToLocation] = useState('NYC');
     const [flightClass, setFlightClass] = useState('economy');
     const [isOneWay, setIsOneWay] = useState(false);
     const [isSearching, setIsSearching] = useState(false);
@@ -51,6 +62,13 @@ const FlightBookingForm: React.FC = () => {
             setBookingState({ status: 'error', message: 'Failed to book flight. Please try again later.' });
         }
     };
+
+    // When the origin changes, keep the destination valid for the new origin.
+    useEffect(() => {
+        if (!destinations.includes(toLocation)) {
+            setToLocation(destinations[0] ?? '');
+        }
+    }, [destinations, toLocation]);
 
     useEffect(() => {
         const today = new Date();
@@ -114,38 +132,18 @@ const FlightBookingForm: React.FC = () => {
                             <div className="fields-container">
                                 <label htmlFor="from">From</label>
                                 <select id="from" name="from" value={fromLocation} onChange={e => setFromLocation(e.target.value)}>
-                                    <option value="SFO">San Francisco (SFO)</option>
-                                    <option value="NYC">New York City (NYC)</option>
-                                    <option value="LAX">Los Angeles (LAX)</option>
-                                    <option value="CHI">Chicago (CHI)</option>
-                                    <option value="ATL">Atlanta (ATL)</option>
-                                    <option value="DFW">Dallas/Fort Worth (DFW)</option>
-                                    <option value="DEN">Denver (DEN)</option>
-                                    <option value="SEA">Seattle (SEA)</option>
-                                    <option value="LAS">Las Vegas (LAS)</option>
-                                    <option value="MIA">Miami (MIA)</option>
-                                    <option value="BOS">Boston (BOS)</option>
-                                    <option value="PHX">Phoenix (PHX)</option>
-                                    <option value="IAH">Houston (IAH)</option>
+                                    {origins.map((loc) => (
+                                        <option key={loc} value={loc}>{loc}</option>
+                                    ))}
                                 </select>
                             </div>
 
                             <div className="fields-container">
                                 <label htmlFor="to">To</label>
                                 <select id="to" name="to" value={toLocation} onChange={e => setToLocation(e.target.value)}>
-                                    <option value="NYC">New York City (NYC)</option>
-                                    <option value="LAX">Los Angeles (LAX)</option>
-                                    <option value="CHI">Chicago (CHI)</option>
-                                    <option value="ATL">Atlanta (ATL)</option>
-                                    <option value="DFW">Dallas/Fort Worth (DFW)</option>
-                                    <option value="DEN">Denver (DEN)</option>
-                                    <option value="SFO">San Francisco (SFO)</option>
-                                    <option value="SEA">Seattle (SEA)</option>
-                                    <option value="LAS">Las Vegas (LAS)</option>
-                                    <option value="MIA">Miami (MIA)</option>
-                                    <option value="BOS">Boston (BOS)</option>
-                                    <option value="PHX">Phoenix (PHX)</option>
-                                    <option value="IAH">Houston (IAH)</option>
+                                    {destinations.map((loc) => (
+                                        <option key={loc} value={loc}>{loc}</option>
+                                    ))}
                                 </select>
                             </div>
 
@@ -189,7 +187,12 @@ const FlightBookingForm: React.FC = () => {
                             </button>
                         </form>
                     </div>
-                    {searchResults && (
+                    {searchResults && searchResults.length === 0 && (
+                        <div className="mt-8 bg-white p-6 rounded-lg shadow-lg max-w-4xl mx-auto text-center text-gray-600">
+                            No flights found for this route. Try a different origin or destination.
+                        </div>
+                    )}
+                    {searchResults && searchResults.length > 0 && (
                         <div className="mt-8 bg-white p-6 rounded-lg shadow-lg max-w-4xl mx-auto">
                             <h2 className="text-2xl font-bold mb-4 text-gray-800">Available Flights</h2>
                             <div className="space-y-4">


### PR DESCRIPTION
## Problem
`searchFlightsAction` ignored its `from`/`to` args and returned **every** flight, and the form's dropdowns were hardcoded airport codes (`SFO`, `NYC`) that never matched the seed flights' city-name format (`San Francisco, USA`). So "search" never actually worked.

## What's now real
- **`searchFlightsAction`** filters flights by `from`/`to`, ordered by departure date.
- **`getFlightRoutesAction`** returns the distinct origin→destination pairs that actually have flights.
- **Inventory-driven, dependent dropdowns**: origin options are the distinct departure cities; destination options are filtered to those reachable from the selected origin — so you can only pick real routes, and the default selection is always a valid route. (Replaces the fragile "first origin + first destination independently" approach.)
- **No-results** message when a route has no flights.
- Home (`/`) and Book (`/book`) pages fetch routes server-side and pass them to the form.

## Verification
- Live Postgres: distinct routes resolve correctly; `Seattle→Detroit` returns `CA101`; a non-route returns empty.
- Unit tests: action from/to filter, the distinct-routes query, dependent-dropdown behavior (origin change updates destinations), default selection, and the no-results branch.
- `tsc --noEmit` 0 errors · `npm run lint` 0 errors · **30 tests** passing.

## Follow-up ideas (not in scope)
Date/class filtering, round-trip pairing, and pagination once inventory grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)