### PR TITLE
Fix Docker production build: make DB-backed pages dynamic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ WORKDIR /app
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then \
-  rm -rf node_modules package-lock.json && npm install; \
+  elif [ -f package-lock.json ]; then npm ci; \
   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
   else echo "Lockfile not found." && exit 1; \
   fi

--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -2,6 +2,10 @@ import FlightBookingForm from "@/components/ui/flightBookingForm";
 import React from 'react';
 import { getFlightRoutesAction } from "@/app/actions";
 
+// Reads live flight inventory from the DB, so render per-request rather than
+// statically prerendering at build time (which would need a database).
+export const dynamic = 'force-dynamic';
+
 export default async function Home() {
   const routes = await getFlightRoutesAction();
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import FlightBookingForm from "../components/ui/flightBookingForm";
 import { getFlightRoutesAction } from "./actions";
 
+// Reads live flight inventory from the DB, so render per-request rather than
+// statically prerendering at build time (which would need a database).
+export const dynamic = 'force-dynamic';
+
 export default async function Home() {
   const routes = await getFlightRoutesAction();
   return (


### PR DESCRIPTION
## Problem
The flight-search change made `/` and `/book` query the DB (`getFlightRoutesAction`) in async server components. With no dynamic marker, `next build` tried to **statically prerender** them and failed — `Can't reach database server at localhost:5432` — because no DB exists at image-build time. This broke `docker compose up --build`.

## Fix
- `export const dynamic = 'force-dynamic'` on `/` and `/book` → render per-request (matches the admin pages; `profile`/`travelguide` are already auto-dynamic via `getServerSession`). They show live inventory, so per-request is correct anyway.
- **Dockerfile**: install with `npm ci` instead of `rm -rf node_modules package-lock.json && npm install`, so the image builds reproducibly from the committed, security-audited lockfile.

## Verification
- `next build` with **no DB** → succeeds (`/`, `/book` reported as `ƒ Dynamic`).
- Full **`docker compose up --build`** → db healthy → migrate (deploy + seed, exit 0) → app serves **HTTP 200**, and the home page renders real seed origins (Chicago, Seattle, …).
- `tsc` 0 · lint 0 errors · **30 tests** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)