### PR TITLE
Remove unused LaunchDarkly stub and dependency

### DIFF
--- a/components/ui/charts/onTimeLineChart.tsx
+++ b/components/ui/charts/onTimeLineChart.tsx
@@ -21,20 +21,8 @@ const chartConfig = {
 } satisfies ChartConfig
 
 import { Suspense } from 'react';
-import LaunchDarklyService from '@/lib/LaunchDarklyService';
 
 const OnTimeLineChart: React.FC<{ ontimeData: { name: string, ontimepercent: number }[] }> = ({ ontimeData }) => {
-    const [showChart, setShowChart] = React.useState(false);
-
-    React.useEffect(() => {
-        const ldService = new LaunchDarklyService();
-        setShowChart(ldService.getFlagStatus('trips-line-chart'));
-    }, []);
-
-    if (!showChart) {
-        return <div></div>;
-    }
-
     return (
         <Suspense fallback={<div>Loading...</div>}>
             <CardContent>

--- a/lib/LaunchDarklyService.ts
+++ b/lib/LaunchDarklyService.ts
@@ -1,6 +1,0 @@
-export default class LaunchDarklyService {
-  getFlagStatus(flagName: string) {
-    return true;
-  }
-}
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "jest-environment-jsdom": "^29.7.0",
-        "launchdarkly-react-client-sdk": "^3.4.0",
         "lucide-react": "^0.447.0",
         "next": "^14.2.35",
         "next-auth": "^4.24.13",
@@ -4221,26 +4220,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/bcryptjs": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
@@ -5515,6 +5494,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6549,14 +6529,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -8057,46 +8029,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/launchdarkly-js-client-sdk": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.9.3.tgz",
-      "integrity": "sha512-1q+TqfBEBQcaz77EHwPf5F0L1hc22iwoa/S+69O5DSyp7+Txg35SDrvIQJWDcpigYxg0WN9VswAiq3uFci1ZhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "launchdarkly-js-sdk-common": "5.8.1"
-      }
-    },
-    "node_modules/launchdarkly-js-sdk-common": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.8.1.tgz",
-      "integrity": "sha512-q6sYOatAhkKJYIT+8eeJyFBy4HZxOjHLxg8028Q6j7/ZdaySbo451ntPnlyKBrvXw9YfyB+62pL9ZHME3U6trg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "fast-deep-equal": "^2.0.1"
-      }
-    },
-    "node_modules/launchdarkly-js-sdk-common/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-      "license": "MIT"
-    },
-    "node_modules/launchdarkly-react-client-sdk": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/launchdarkly-react-client-sdk/-/launchdarkly-react-client-sdk-3.4.0.tgz",
-      "integrity": "sha512-2HmwmIuUGz48xcuWNrOgSU6g9dpid6lcn4WwjwVccy8wHD2FqvPpKG9q676Uyt8nrQ6CXGW9UAlJkACLYfuvTw==",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.2",
-        "launchdarkly-js-client-sdk": "^3.3.0",
-        "lodash.camelcase": "^4.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.3 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8152,11 +8084,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "jest-environment-jsdom": "^29.7.0",
-    "launchdarkly-react-client-sdk": "^3.4.0",
     "lucide-react": "^0.447.0",
     "next": "^14.2.35",
     "next-auth": "^4.24.13",


### PR DESCRIPTION
## What
`LaunchDarklyService` was a stub whose `getFlagStatus()` always returned `true`, used in one place to gate the on-time chart (so it always rendered — just after a hydration flash). The real `launchdarkly-react-client-sdk` dependency was never imported anywhere.

- Delete `lib/LaunchDarklyService.ts`
- Render the on-time chart directly (drop the `showChart` state/effect/guard in `onTimeLineChart.tsx`)
- Uninstall the unused `launchdarkly-react-client-sdk` dependency

## Honest note on vulnerabilities
This does **not** lower the `npm audit` count (still 15). The vulnerable `uuid` the LD SDK pulled is **also** required by `next-auth`, so that advisory persists. The value here is removing dead code + an unused SDK and its transitive packages — not a net vuln reduction. (The `uuid`/`cookie` advisories clear only with a `next-auth` major upgrade, which is deferred.)

## Verification
- `tsc --noEmit` 0 · `npm run lint` 0 errors · **30 tests** passing
- No `launchdarkly` references remain in source or lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)