### PR TITLE
fix(security): protect runtime secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,10 @@ npm-debug.log
 README.md
 .next
 .git
+.env
+.env.*
+.agents
+.claude
+.codex
+.cursor
+.github

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Local development values only. Replace every value for deployed environments.
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/travel_app
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/travel_app
-      NEXTAUTH_SECRET: supersecretjwtpassphrase12345
+      NEXTAUTH_SECRET: ci-only-nextauth-secret-at-least-32-characters
       NEXTAUTH_URL: http://localhost:3000
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +54,48 @@ jobs:
 
       - name: Run Playwright E2E tests
         run: npx playwright test
+
+      - name: Build and inspect production container
+        run: |
+          sentinel="travel-app-secret-scan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          printf 'NEXTAUTH_SECRET=%s\n' "$sentinel" > .env.secret-scan
+          docker build --tag travel-app:ci .
+          SECRET_SCAN_SENTINEL="$sentinel" ./scripts/verify-container-secrets.sh travel-app:ci
+
+          printf '%s\n' "$sentinel" > layer-sentinel.txt
+          printf '%s\n' \
+            'FROM travel-app:ci' \
+            'USER root' \
+            'COPY layer-sentinel.txt /tmp/layer-sentinel.txt' \
+            'RUN rm /tmp/layer-sentinel.txt' \
+            'USER nextjs' > Dockerfile.secret-probe
+          docker build --file Dockerfile.secret-probe --tag travel-app:secret-probe .
+
+          if SECRET_SCAN_SENTINEL="$sentinel" \
+            ./scripts/verify-container-secrets.sh travel-app:secret-probe; then
+            echo "Expected layer secret probe to be rejected." >&2
+            exit 1
+          fi
+
+          docker image rm travel-app:secret-probe
+          rm -f Dockerfile.secret-probe layer-sentinel.txt
+
+          printf '%s\n' \
+            'FROM travel-app:ci' \
+            'USER root' \
+            'RUN printf "probe\\n" > /tmp/.env.secret' \
+            'RUN rm /tmp/.env.secret' \
+            'USER nextjs' > Dockerfile.env-layer-probe
+          docker build --file Dockerfile.env-layer-probe --tag travel-app:env-layer-probe .
+
+          if ./scripts/verify-container-secrets.sh travel-app:env-layer-probe; then
+            echo "Expected environment-file layer probe to be rejected." >&2
+            exit 1
+          fi
+
+          docker image rm travel-app:env-layer-probe
+          rm -f Dockerfile.env-layer-probe
+          rm -f .env.secret-scan
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,15 @@ RUN \
   else echo "Lockfile not found." && exit 1; \
   fi
 
+# Fail closed if a framework or build change ever copies local environment
+# files into the standalone server artifact.
+RUN test -z "$(find .next/standalone -type f -name '.env*' -print -quit)"
+
 # Production image, copy all the files and run next
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
@@ -55,13 +59,15 @@ RUN chown nextjs:nodejs .next
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --chmod=755 scripts/container-entrypoint.sh /app/scripts/container-entrypoint.sh
 
 USER nextjs
 
 EXPOSE 3000
 
-ENV PORT 3000
+ENV PORT=3000
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
+ENTRYPOINT ["/app/scripts/container-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@ This is the website for Mona Airways. Fly with the Octocat!
 
 ## Getting Started
 
+Copy the safe environment template before starting the application:
+
+```bash
+cp .env.example .env
+```
+
+Replace `NEXTAUTH_SECRET` with a securely generated value of at least 32
+characters. Deployed environments must inject all configuration at runtime;
+never bake `.env` into an image. See [SECURITY.md](SECURITY.md) for rotation and
+incident guidance.
+
 ### Using Docker (Recommended)
 
 To quickly get the application running with a database and demo data, use Docker:

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -51,12 +51,12 @@ authoritative before expanding the product.
 
 ### P0.1 Protect build and runtime secrets
 
-- [ ] Exclude `.env` and `.env*` from the Docker build context.
-- [ ] Ensure `.next/standalone` and the final image contain no environment
+- [x] Exclude `.env` and `.env*` from the Docker build context.
+- [x] Ensure `.next/standalone` and the final image contain no environment
   files or secret values.
-- [ ] Inject runtime configuration through the deployment environment.
-- [ ] Validate required environment variables during application startup.
-- [ ] Document secret rotation for any image that may have been published.
+- [x] Inject runtime configuration through the deployment environment.
+- [x] Validate required environment variables during application startup.
+- [x] Document secret rotation for any image that may have been published.
 
 Acceptance criteria:
 
@@ -497,6 +497,7 @@ Add one row when work starts, becomes blocked, or completes.
 | Date | Item | Status | PR | Notes |
 | --- | --- | --- | --- | --- |
 | 2026-07-11 | Roadmap baseline | Complete | — | Browser, source, Jest, Playwright, build, lint, and dependency audit reviewed. |
+| 2026-07-11 | P0.1 | Complete | TBD | Excluded local secrets, added fail-closed runtime validation, sanitized standalone builds, scanned final image content and layers, and documented rotation. |
 
 ## Recommended first delivery sequence
 

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -497,7 +497,7 @@ Add one row when work starts, becomes blocked, or completes.
 | Date | Item | Status | PR | Notes |
 | --- | --- | --- | --- | --- |
 | 2026-07-11 | Roadmap baseline | Complete | — | Browser, source, Jest, Playwright, build, lint, and dependency audit reviewed. |
-| 2026-07-11 | P0.1 | Complete | TBD | Excluded local secrets, added fail-closed runtime validation, sanitized standalone builds, scanned final image content and layers, and documented rotation. |
+| 2026-07-11 | P0.1 | Complete | #34 | Excluded local secrets, added fail-closed runtime validation, sanitized standalone builds, scanned final image content and layers, and documented rotation. |
 
 ## Recommended first delivery sequence
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Secrets and configuration
+
+- Keep local secrets in `.env`; never commit that file or copy it into a
+  container image.
+- Use `.env.example` only as a list of required settings. It must contain
+  placeholders or local-only values, never production credentials.
+- Inject `DATABASE_URL`, `NEXTAUTH_URL`, and `NEXTAUTH_SECRET` through the
+  runtime environment in deployed environments.
+- Generate `NEXTAUTH_SECRET` with a cryptographically secure generator and use
+  at least 32 characters.
+- Store deployment secrets in the hosting platform's secret manager and limit
+  access to the people and workloads that require them.
+
+The application validates required server settings during Node.js startup. A
+missing or malformed setting prevents startup instead of allowing a partially
+configured deployment.
+
+## Responding to an image that contains secrets
+
+If an image containing `.env` or another secret is published, deleting the
+image is not sufficient. Treat every value in that image as exposed.
+
+1. Restrict or remove access to the affected image and record its registry,
+   repository, digest, tags, and deployment history.
+2. **Rotate exposed secrets** at their source, including the database password,
+   `NEXTAUTH_SECRET`, and any other credential present in the image.
+3. Revoke old credentials and invalidate active sessions when the rotated value
+   can authenticate a user or service.
+4. Review registry, deployment, authentication, and database audit logs for
+   unexpected access.
+5. **Rebuild and redeploy** from a clean commit using newly issued secrets
+   injected only at runtime.
+6. Verify the replacement image with
+   `scripts/verify-container-secrets.sh IMAGE` before promotion.
+7. Record the incident, impact assessment, remediation, and follow-up actions.
+
+## Reporting a vulnerability
+
+Do not open a public issue containing credentials, personal data, or exploit
+details. Contact the repository owner privately with the affected component,
+reproduction steps, impact, and any suggested mitigation.

--- a/__tests__/instrumentation.test.ts
+++ b/__tests__/instrumentation.test.ts
@@ -1,0 +1,38 @@
+import { register } from '@/instrumentation';
+
+const originalEnvironment = process.env;
+
+describe('server instrumentation', () => {
+    beforeEach(() => {
+        process.env = {
+            ...originalEnvironment,
+            NEXT_RUNTIME: 'nodejs',
+            DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/travel_app',
+            NEXTAUTH_URL: 'http://localhost:3000',
+            NEXTAUTH_SECRET: 'a-secure-test-secret-that-is-at-least-32-characters',
+        };
+    });
+
+    afterAll(() => {
+        process.env = originalEnvironment;
+    });
+
+    it('validates the environment when the Node.js server starts', () => {
+        expect(() => register()).not.toThrow();
+    });
+
+    it('fails startup when a required setting is absent', () => {
+        delete process.env.NEXTAUTH_SECRET;
+
+        expect(() => register()).toThrow(
+            'Missing required environment variable: NEXTAUTH_SECRET'
+        );
+    });
+
+    it('does not run server validation in the edge runtime', () => {
+        process.env.NEXT_RUNTIME = 'edge';
+        delete process.env.NEXTAUTH_SECRET;
+
+        expect(() => register()).not.toThrow();
+    });
+});

--- a/__tests__/lib/env.test.ts
+++ b/__tests__/lib/env.test.ts
@@ -1,0 +1,46 @@
+import { validateServerEnvironment } from '@/lib/env';
+
+const validEnvironment = {
+    DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/travel_app',
+    NEXTAUTH_URL: 'http://localhost:3000',
+    NEXTAUTH_SECRET: 'a-secure-test-secret-that-is-at-least-32-characters',
+};
+
+describe('validateServerEnvironment', () => {
+    it('returns validated values when all required settings are present', () => {
+        expect(validateServerEnvironment(validEnvironment)).toEqual(validEnvironment);
+    });
+
+    it.each(['DATABASE_URL', 'NEXTAUTH_URL', 'NEXTAUTH_SECRET'] as const)(
+        'rejects a missing %s',
+        (key) => {
+            const environment = { ...validEnvironment };
+            delete environment[key];
+
+            expect(() => validateServerEnvironment(environment)).toThrow(
+                `Missing required environment variable: ${key}`
+            );
+        }
+    );
+
+    it('rejects a non-PostgreSQL database URL', () => {
+        expect(() => validateServerEnvironment({
+            ...validEnvironment,
+            DATABASE_URL: 'https://database.example.com/travel_app',
+        })).toThrow('DATABASE_URL must use the postgresql:// or postgres:// protocol');
+    });
+
+    it('rejects an invalid NextAuth URL', () => {
+        expect(() => validateServerEnvironment({
+            ...validEnvironment,
+            NEXTAUTH_URL: 'not-a-url',
+        })).toThrow('NEXTAUTH_URL must be a valid http:// or https:// URL');
+    });
+
+    it('rejects a short NextAuth secret', () => {
+        expect(() => validateServerEnvironment({
+            ...validEnvironment,
+            NEXTAUTH_SECRET: 'too-short',
+        })).toThrow('NEXTAUTH_SECRET must be at least 32 characters');
+    });
+});

--- a/__tests__/security/containerEntrypoint.test.ts
+++ b/__tests__/security/containerEntrypoint.test.ts
@@ -1,0 +1,57 @@
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+const entrypoint = path.resolve(__dirname, '../../scripts/container-entrypoint.sh');
+const validEnvironment: NodeJS.ProcessEnv = {
+    NODE_ENV: 'test',
+    DATABASE_URL: 'postgresql://postgres:postgres@db:5432/travel_app',
+    NEXTAUTH_URL: 'http://localhost:3000',
+    NEXTAUTH_SECRET: 'a-secure-test-secret-that-is-at-least-32-characters',
+};
+
+function runEntrypoint(environment: NodeJS.ProcessEnv) {
+    return spawnSync('sh', [entrypoint, 'true'], {
+        env: environment,
+        encoding: 'utf8',
+    });
+}
+
+describe('container entrypoint', () => {
+    it('starts the requested command when configuration is valid', () => {
+        expect(runEntrypoint(validEnvironment).status).toBe(0);
+    });
+
+    it.each(['DATABASE_URL', 'NEXTAUTH_URL', 'NEXTAUTH_SECRET'] as const)(
+        'fails before startup when %s is missing',
+        (key) => {
+            const environment = { ...validEnvironment };
+            delete environment[key];
+
+            const result = runEntrypoint(environment);
+
+            expect(result.status).not.toBe(0);
+            expect(`${result.stdout}${result.stderr}`).toContain(
+                `Missing required environment variable: ${key}`
+            );
+        }
+    );
+
+    it('rejects invalid URL protocols and short secrets', () => {
+        const invalidDatabase = runEntrypoint({
+            ...validEnvironment,
+            DATABASE_URL: 'https://database.example.com/travel_app',
+        });
+        const invalidNextAuth = runEntrypoint({
+            ...validEnvironment,
+            NEXTAUTH_URL: 'ftp://localhost:3000',
+        });
+        const shortSecret = runEntrypoint({
+            ...validEnvironment,
+            NEXTAUTH_SECRET: 'too-short',
+        });
+
+        expect(invalidDatabase.status).not.toBe(0);
+        expect(invalidNextAuth.status).not.toBe(0);
+        expect(shortSecret.status).not.toBe(0);
+    });
+});

--- a/__tests__/security/containerSecrets.test.ts
+++ b/__tests__/security/containerSecrets.test.ts
@@ -1,0 +1,73 @@
+import fs from 'fs';
+import path from 'path';
+
+const repositoryRoot = path.resolve(__dirname, '../..');
+
+function readRepositoryFile(filePath: string): string {
+    return fs.readFileSync(path.join(repositoryRoot, filePath), 'utf8');
+}
+
+describe('container secret protection', () => {
+    it('excludes local environment files from the Docker build context', () => {
+        const ignoredEntries = readRepositoryFile('.dockerignore')
+            .split(/\r?\n/)
+            .map((entry) => entry.trim());
+
+        expect(ignoredEntries).toEqual(expect.arrayContaining([
+            '.env',
+            '.env.*',
+            '.agents',
+            '.claude',
+            '.codex',
+            '.cursor',
+            '.github',
+        ]));
+    });
+
+    it('fails the image build if standalone output contains an environment file', () => {
+        const dockerfile = readRepositoryFile('Dockerfile');
+        const packageJson = readRepositoryFile('package.json');
+
+        expect(dockerfile).toContain(
+            `RUN test -z "$(find .next/standalone -type f -name '.env*' -print -quit)"`
+        );
+        expect(dockerfile).toContain('ENTRYPOINT ["/app/scripts/container-entrypoint.sh"]');
+        expect(packageJson).toContain('next build && node scripts/sanitize-standalone.mjs');
+    });
+
+    it('injects authentication configuration into the app container at runtime', () => {
+        const composeFile = readRepositoryFile('docker-compose.yml');
+
+        expect(composeFile).toContain('NEXTAUTH_URL: ${NEXTAUTH_URL:?NEXTAUTH_URL is required}');
+        expect(composeFile).toContain('NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}');
+    });
+
+    it('checks the final container image in CI', () => {
+        const workflow = readRepositoryFile('.github/workflows/ci.yml');
+        const verificationScript = readRepositoryFile('scripts/verify-container-secrets.sh');
+
+        expect(workflow).toContain('.env.secret-scan');
+        expect(workflow).toContain('SECRET_SCAN_SENTINEL="$sentinel"');
+        expect(workflow).toContain('docker build --tag travel-app:ci .');
+        expect(workflow).toContain('travel-app:secret-probe');
+        expect(workflow).toContain('travel-app:env-layer-probe');
+        expect(workflow).toContain('./scripts/verify-container-secrets.sh travel-app:ci');
+        expect(verificationScript).toContain('image inspect');
+        expect(verificationScript).toContain('export --output');
+        expect(verificationScript).toContain('save --output');
+        expect(verificationScript).toContain('scan-image-layers.sh');
+        expect(verificationScript).toContain('SECRET_SCAN_SENTINEL');
+    });
+
+    it('provides safe configuration and secret-rotation guidance', () => {
+        const exampleEnvironment = readRepositoryFile('.env.example');
+        const securityGuide = readRepositoryFile('SECURITY.md');
+
+        expect(exampleEnvironment).toContain('DATABASE_URL=');
+        expect(exampleEnvironment).toContain('NEXTAUTH_URL=');
+        expect(exampleEnvironment).toContain('NEXTAUTH_SECRET=');
+        expect(exampleEnvironment.match(/^NEXTAUTH_SECRET=(.*)$/m)?.[1]).toBe('');
+        expect(securityGuide).toContain('Rotate exposed secrets');
+        expect(securityGuide).toContain('Rebuild and redeploy');
+    });
+});

--- a/__tests__/security/sanitizeStandalone.test.ts
+++ b/__tests__/security/sanitizeStandalone.test.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const sanitizer = path.resolve(__dirname, '../../scripts/sanitize-standalone.mjs');
+
+describe('standalone environment-file sanitizer', () => {
+    let temporaryDirectory: string;
+
+    beforeEach(() => {
+        temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'travel-app-standalone-'));
+        fs.mkdirSync(path.join(temporaryDirectory, 'nested'));
+        fs.writeFileSync(path.join(temporaryDirectory, '.env'), 'SECRET=local');
+        fs.writeFileSync(path.join(temporaryDirectory, '.env.production'), 'SECRET=production');
+        fs.writeFileSync(path.join(temporaryDirectory, 'nested/.env.local'), 'SECRET=nested');
+        fs.writeFileSync(path.join(temporaryDirectory, 'server.js'), 'console.log("server");');
+    });
+
+    afterEach(() => {
+        fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    });
+
+    it('removes environment files without changing application files', () => {
+        const result = spawnSync('node', [sanitizer, temporaryDirectory], {
+            encoding: 'utf8',
+        });
+
+        expect(result.status).toBe(0);
+        expect(fs.existsSync(path.join(temporaryDirectory, '.env'))).toBe(false);
+        expect(fs.existsSync(path.join(temporaryDirectory, '.env.production'))).toBe(false);
+        expect(fs.existsSync(path.join(temporaryDirectory, 'nested/.env.local'))).toBe(false);
+        expect(fs.existsSync(path.join(temporaryDirectory, 'server.js'))).toBe(true);
+        expect(result.stdout).toContain('Removed 3 environment files from standalone output.');
+    });
+
+    it('fails clearly when the standalone directory does not exist', () => {
+        const missingDirectory = path.join(temporaryDirectory, 'missing');
+        const result = spawnSync('node', [sanitizer, missingDirectory], {
+            encoding: 'utf8',
+        });
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(`Standalone output not found: ${missingDirectory}`);
+    });
+});

--- a/__tests__/security/scanImageLayers.test.ts
+++ b/__tests__/security/scanImageLayers.test.ts
@@ -1,0 +1,91 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const scanner = path.resolve(__dirname, '../../scripts/scan-image-layers.sh');
+
+function createClassicImageArchive(files: Record<string, string>): {
+    archive: string;
+    root: string;
+} {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'travel-app-image-archive-'));
+    const layerRoot = path.join(root, 'layer-root');
+    const archiveRoot = path.join(root, 'archive-root');
+    const layerDirectory = path.join(archiveRoot, 'layer-sha');
+    const layerArchive = path.join(layerDirectory, 'layer.tar');
+    const archive = path.join(root, 'image.tar');
+
+    fs.mkdirSync(layerRoot);
+    fs.mkdirSync(layerDirectory, { recursive: true });
+
+    for (const [fileName, content] of Object.entries(files)) {
+        const filePath = path.join(layerRoot, fileName);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, content);
+    }
+
+    expect(spawnSync('tar', ['-cf', layerArchive, '-C', layerRoot, '.']).status).toBe(0);
+    fs.writeFileSync(path.join(archiveRoot, 'manifest.json'), '[]');
+    expect(spawnSync('tar', ['-cf', archive, '-C', archiveRoot, '.']).status).toBe(0);
+
+    return { archive, root };
+}
+
+describe('image layer archive scanner', () => {
+    const temporaryDirectories: string[] = [];
+
+    afterEach(() => {
+        for (const directory of temporaryDirectories.splice(0)) {
+            fs.rmSync(directory, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects an environment file in a classic Docker archive layer', () => {
+        const fixture = createClassicImageArchive({ '.env.secret': 'not-a-real-secret' });
+        temporaryDirectories.push(fixture.root);
+
+        const result = spawnSync('sh', [scanner, fixture.archive], { encoding: 'utf8' });
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain('Environment file found in an image layer.');
+    });
+
+    it('accepts a clean classic archive and reports scanned layers', () => {
+        const fixture = createClassicImageArchive({ 'app/server.js': 'console.log("ok");' });
+        temporaryDirectories.push(fixture.root);
+
+        const result = spawnSync('sh', [scanner, fixture.archive], { encoding: 'utf8' });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Scanned 1 image layer.');
+    });
+
+    it('rejects sentinel content in a classic archive layer', () => {
+        const sentinel = 'classic-archive-secret-sentinel';
+        const fixture = createClassicImageArchive({ 'app/bundle.js': sentinel });
+        temporaryDirectories.push(fixture.root);
+
+        const result = spawnSync('sh', [scanner, fixture.archive, sentinel], {
+            encoding: 'utf8',
+        });
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain('Secret-scan sentinel found in an image layer.');
+    });
+
+    it('fails closed when an archive contains no readable layers', () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'travel-app-empty-archive-'));
+        const archiveRoot = path.join(root, 'archive-root');
+        const archive = path.join(root, 'image.tar');
+        temporaryDirectories.push(root);
+        fs.mkdirSync(archiveRoot);
+        fs.writeFileSync(path.join(archiveRoot, 'manifest.json'), '[]');
+        expect(spawnSync('tar', ['-cf', archive, '-C', archiveRoot, '.']).status).toBe(0);
+
+        const result = spawnSync('sh', [scanner, archive], { encoding: 'utf8' });
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain('No readable image layers found in archive.');
+    });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - DATABASE_URL=postgresql://postgres:postgres@db:5432/travel_app
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/travel_app
+      NEXTAUTH_URL: ${NEXTAUTH_URL:?NEXTAUTH_URL is required}
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -17,7 +19,7 @@ services:
       dockerfile: Dockerfile
       target: builder
     environment:
-      - DATABASE_URL=postgresql://postgres:postgres@db:5432/travel_app
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/travel_app
     command: sh -c "npx prisma migrate deploy && npx prisma db seed"
     depends_on:
       db:
@@ -27,9 +29,9 @@ services:
     image: postgres:15-alpine
     restart: always
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=travel_app
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: travel_app
     ports:
       - "5432:5432"
     volumes:

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,7 @@
+import { validateServerEnvironment } from '@/lib/env';
+
+export function register() {
+    if (process.env.NEXT_RUNTIME === 'nodejs') {
+        validateServerEnvironment(process.env);
+    }
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,49 @@
+type RequiredEnvironmentVariable = 'DATABASE_URL' | 'NEXTAUTH_URL' | 'NEXTAUTH_SECRET';
+type Environment = Partial<Record<RequiredEnvironmentVariable, string | undefined>>;
+type ValidatedEnvironment = Record<RequiredEnvironmentVariable, string>;
+
+function requireValue(environment: Environment, key: RequiredEnvironmentVariable): string {
+    const value = environment[key]?.trim();
+
+    if (!value) {
+        throw new Error(`Missing required environment variable: ${key}`);
+    }
+
+    return value;
+}
+
+function parseUrl(value: string, key: RequiredEnvironmentVariable): URL {
+    try {
+        return new URL(value);
+    } catch {
+        throw new Error(`${key} must be a valid URL`);
+    }
+}
+
+export function validateServerEnvironment(environment: Environment): ValidatedEnvironment {
+    const DATABASE_URL = requireValue(environment, 'DATABASE_URL');
+    const NEXTAUTH_URL = requireValue(environment, 'NEXTAUTH_URL');
+    const NEXTAUTH_SECRET = requireValue(environment, 'NEXTAUTH_SECRET');
+
+    const databaseUrl = parseUrl(DATABASE_URL, 'DATABASE_URL');
+    if (!['postgresql:', 'postgres:'].includes(databaseUrl.protocol)) {
+        throw new Error('DATABASE_URL must use the postgresql:// or postgres:// protocol');
+    }
+
+    let nextAuthUrl: URL;
+    try {
+        nextAuthUrl = new URL(NEXTAUTH_URL);
+    } catch {
+        throw new Error('NEXTAUTH_URL must be a valid http:// or https:// URL');
+    }
+
+    if (!['http:', 'https:'].includes(nextAuthUrl.protocol)) {
+        throw new Error('NEXTAUTH_URL must be a valid http:// or https:// URL');
+    }
+
+    if (NEXTAUTH_SECRET.length < 32) {
+        throw new Error('NEXTAUTH_SECRET must be at least 32 characters');
+    }
+
+    return { DATABASE_URL, NEXTAUTH_URL, NEXTAUTH_SECRET };
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
+    experimental: {
+        instrumentationHook: true,
+    },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && node scripts/sanitize-standalone.mjs",
     "start": "next start",
     "lint": "next lint",
     "test": "npx jest"

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -eu
+
+require_value() {
+  variable_name="$1"
+  eval "variable_value=\${$variable_name:-}"
+
+  if [ -z "$variable_value" ]; then
+    echo "Missing required environment variable: $variable_name" >&2
+    exit 1
+  fi
+}
+
+require_value DATABASE_URL
+require_value NEXTAUTH_URL
+require_value NEXTAUTH_SECRET
+
+case "$DATABASE_URL" in
+  postgres://*|postgresql://*) ;;
+  *)
+    echo "DATABASE_URL must use the postgresql:// or postgres:// protocol" >&2
+    exit 1
+    ;;
+esac
+
+case "$NEXTAUTH_URL" in
+  http://*|https://*) ;;
+  *)
+    echo "NEXTAUTH_URL must be a valid http:// or https:// URL" >&2
+    exit 1
+    ;;
+esac
+
+if [ "${#NEXTAUTH_SECRET}" -lt 32 ]; then
+  echo "NEXTAUTH_SECRET must be at least 32 characters" >&2
+  exit 1
+fi
+
+exec "$@"

--- a/scripts/sanitize-standalone.mjs
+++ b/scripts/sanitize-standalone.mjs
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const standaloneDirectory = path.resolve(process.argv[2] ?? '.next/standalone');
+
+if (!fs.existsSync(standaloneDirectory)) {
+    console.error(`Standalone output not found: ${standaloneDirectory}`);
+    process.exit(1);
+}
+
+let removedCount = 0;
+
+function removeEnvironmentFiles(directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const entryPath = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            removeEnvironmentFiles(entryPath);
+        } else if (entry.name === '.env' || entry.name.startsWith('.env.')) {
+            fs.rmSync(entryPath);
+            removedCount += 1;
+        }
+    }
+}
+
+removeEnvironmentFiles(standaloneDirectory);
+
+console.log(`Removed ${removedCount} environment files from standalone output.`);

--- a/scripts/scan-image-layers.sh
+++ b/scripts/scan-image-layers.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+set -eu
+
+image_archive="${1:?Usage: scan-image-layers.sh IMAGE_ARCHIVE [SENTINEL]}"
+sentinel="${2:-}"
+archive_contents="$(mktemp -d)"
+candidate_list="$(mktemp)"
+
+cleanup() {
+  rm -f "$candidate_list"
+  rm -rf "$archive_contents"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+tar -xf "$image_archive" -C "$archive_contents"
+find "$archive_contents" -type f -print > "$candidate_list"
+
+layer_count=0
+
+while IFS= read -r candidate; do
+  if tar -tf "$candidate" >/dev/null 2>&1; then
+    layer_count=$((layer_count + 1))
+
+    if tar -tf "$candidate" | grep -Eq '(^|/)\.env($|\.)'; then
+      echo "Environment file found in an image layer." >&2
+      exit 1
+    fi
+
+    if [ -n "$sentinel" ] && \
+      tar -xOf "$candidate" 2>/dev/null | grep -a -F -q -- "$sentinel"; then
+      echo "Secret-scan sentinel found in an image layer." >&2
+      exit 1
+    fi
+  elif [ -n "$sentinel" ] && grep -a -F -q -- "$sentinel" "$candidate"; then
+    echo "Secret-scan sentinel found in image metadata." >&2
+    exit 1
+  fi
+done < "$candidate_list"
+
+if [ "$layer_count" -eq 0 ]; then
+  echo "No readable image layers found in archive." >&2
+  exit 1
+fi
+
+if [ "$layer_count" -eq 1 ]; then
+  echo "Scanned 1 image layer."
+else
+  echo "Scanned $layer_count image layers."
+fi

--- a/scripts/verify-container-secrets.sh
+++ b/scripts/verify-container-secrets.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+set -eu
+
+image="${1:?Usage: verify-container-secrets.sh IMAGE}"
+container_runtime="${CONTAINER_RUNTIME:-docker}"
+sentinel="${SECRET_SCAN_SENTINEL:-}"
+script_directory="$(CDPATH='' cd "$(dirname "$0")" && pwd)"
+
+if ! command -v "$container_runtime" >/dev/null 2>&1; then
+  echo "Container runtime not found: $container_runtime" >&2
+  exit 1
+fi
+
+archive="$(mktemp)"
+image_archive="$(mktemp)"
+container_id=""
+
+cleanup() {
+  if [ -n "$container_id" ]; then
+    "$container_runtime" rm --force "$container_id" >/dev/null 2>&1 || true
+  fi
+  rm -f "$archive"
+  rm -f "$image_archive"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+image_environment="$($container_runtime image inspect \
+  --format '{{range .Config.Env}}{{println .}}{{end}}' "$image")"
+image_labels="$($container_runtime image inspect \
+  --format '{{json .Config.Labels}}' "$image")"
+
+if printf '%s\n' "$image_environment" | \
+  grep -Eq '^(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET)='; then
+  echo "Sensitive runtime configuration key found in image environment." >&2
+  exit 1
+fi
+
+if printf '%s\n' "$image_labels" | \
+  grep -Eq '"(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET)"[[:space:]]*:'; then
+  echo "Sensitive runtime configuration key found in image labels." >&2
+  exit 1
+fi
+
+container_id="$($container_runtime create "$image")"
+"$container_runtime" export --output "$archive" "$container_id"
+
+if tar -tf "$archive" | grep -Eq '(^|/)\.env($|\.)'; then
+  echo "Environment file found in final container filesystem." >&2
+  exit 1
+fi
+
+"$container_runtime" save --output "$image_archive" "$image"
+
+if [ -n "$sentinel" ]; then
+  if grep -a -F -q -- "$sentinel" "$archive"; then
+    echo "Secret-scan sentinel found in final container filesystem." >&2
+    exit 1
+  fi
+
+  if "$container_runtime" image inspect "$image" | grep -F -q -- "$sentinel"; then
+    echo "Secret-scan sentinel found in image configuration." >&2
+    exit 1
+  fi
+
+fi
+
+"$script_directory/scan-image-layers.sh" "$image_archive" "$sentinel"
+
+echo "No environment files, sensitive config keys, or sentinel values found in container image."


### PR DESCRIPTION
## Summary

Complete roadmap item P0.1 by preventing local configuration and secret values from entering standalone artifacts or container images, and by failing server startup when required runtime configuration is invalid.

## Changes

- exclude environment and workspace-only files from Docker build context
- sanitize ordinary Next.js standalone builds and guard Docker output
- validate database and authentication configuration at startup
- inject authentication settings into the app container at runtime
- scan final filesystems, image config, metadata, and historical OCI/classic layers
- add CI probes for ignored sentinels, deleted secret layers, and deleted environment-file layers
- add safe environment examples and secret-rotation guidance
- mark P0.1 complete in the real-world roadmap

## Key implementation decisions

- keep runtime validation in Next instrumentation and a fail-closed container entrypoint
- remove framework-copied environment files after every standalone build
- use layout-agnostic tar-readable layer discovery for Docker and Podman portability
- fail image verification when no readable layer is found

## Testing

- [x] 150 Jest tests
- [x] 8 Playwright Chromium journeys
- [x] TypeScript, lint, ShellCheck, sh/dash syntax, and production build
- [x] Docker Compose configuration validation
- [x] Clean Docker image build and 17-layer scan
- [x] Missing configuration fails closed; valid configuration reaches Ready
- [x] Classic archive and zero-layer behavioral fixtures
- [x] Deleted sentinel and deleted `.env` historical-layer rejection probes

## Screenshots (if applicable)

Not applicable; no rendered UI changes.

## Related Issues

Roadmap: P0.1
