### PR TITLE
chore(tooling): add shared agent configuration

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
+      "port": 3000
+    }
+  ]
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor before-submit-prompt'"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor pre-compact'"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-end'"
+      }
+    ],
+    "sessionStart": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-start'"
+      }
+    ],
+    "stop": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor stop'"
+      }
+    ],
+    "subagentStart": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-start'"
+      }
+    ],
+    "subagentStop": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-stop'"
+      }
+    ]
+  },
+  "version": 1
+}

--- a/.github/hooks/entire.json
+++ b/.github/hooks/entire.json
@@ -1,0 +1,61 @@
+{
+  "hooks": {
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli agent-stop'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "errorOccurred": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli error-occurred'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli post-tool-use'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli pre-tool-use'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli session-end'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli session-start'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "subagentStop": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli subagent-stop'",
+        "comment": "Entire CLI"
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks copilot-cli user-prompt-submitted'",
+        "comment": "Entire CLI"
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Check shared Claude, Cursor, and GitHub Copilot agent configuration into the repository so contributors and coding agents use consistent tooling.

## Changes

- add a credential-free Claude development launch profile using `npm run dev`
- add Cursor lifecycle hooks for Entire CLI
- add GitHub Copilot CLI lifecycle hooks for Entire CLI
- make every Entire hook safely no-op when the CLI is unavailable

## Testing

- [x] JSON syntax and configuration shape validated
- [x] Confirmed the launch profile uses the existing `dev` script
- [x] Executed hook guards without Entire installed and confirmed exit 0
- [x] Scanned for secrets, credentials, and machine-specific paths
- [ ] Manual testing steps: N/A; developer-tool configuration only

## Screenshots (if applicable)

Not applicable; no application UI changes.

## Related Issues

None.