### PR TITLE
feat(validation): add authoritative server schemas

### DIFF
--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -84,12 +84,12 @@ Acceptance criteria:
 
 ### P0.3 Add authoritative server validation
 
-- [ ] Introduce shared schemas for registration, reviews, favorites, city
+- [x] Introduce shared schemas for registration, reviews, favorites, city
   guides, schedules, passengers, seat changes, and booking requests.
-- [ ] Normalize and validate identifiers, email addresses, dates, enum values,
+- [x] Normalize and validate identifiers, email addresses, dates, enum values,
   text lengths, and array limits.
-- [ ] Return structured, customer-safe validation errors.
-- [ ] Add request and mutation size limits.
+- [x] Return structured, customer-safe validation errors.
+- [x] Add request and mutation size limits.
 
 Acceptance criteria:
 
@@ -500,6 +500,7 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-11 | P0.1 | Complete | #34 | Excluded local secrets, added fail-closed runtime validation, sanitized standalone builds, scanned final image content and layers, and documented rotation. |
 | 2026-07-12 | P0.2 | Complete | #35 | Upgraded Next.js, Auth, D3, Node, and ESLint; cleared the production audit; and added CI enforcement. |
 | 2026-07-12 | P1.4 | In progress | #32 | Added a concurrency-safe manual occurrence generator with custom seating; scheduled background generation and horizon monitoring remain. |
+| 2026-07-12 | P0.3 | Complete | Pending | Added shared Zod schemas, normalized mutation inputs, structured safe errors, and request/mutation limits. |
 
 ## Recommended first delivery sequence
 

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -500,7 +500,7 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-11 | P0.1 | Complete | #34 | Excluded local secrets, added fail-closed runtime validation, sanitized standalone builds, scanned final image content and layers, and documented rotation. |
 | 2026-07-12 | P0.2 | Complete | #35 | Upgraded Next.js, Auth, D3, Node, and ESLint; cleared the production audit; and added CI enforcement. |
 | 2026-07-12 | P1.4 | In progress | #32 | Added a concurrency-safe manual occurrence generator with custom seating; scheduled background generation and horizon monitoring remain. |
-| 2026-07-12 | P0.3 | Complete | Pending | Added shared Zod schemas, normalized mutation inputs, structured safe errors, and request/mutation limits. |
+| 2026-07-12 | P0.3 | Complete | #37 | Added shared Zod schemas, normalized mutation inputs, structured safe errors, and request/mutation limits. |
 
 ## Recommended first delivery sequence
 

--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -136,6 +136,22 @@ describe('saveCityGuideAction authorization', () => {
         expect(mockSaveCityGuide).toHaveBeenCalledWith(sampleGuide);
         expect(result).toHaveProperty('id', 1);
     });
+
+    it('normalizes guide text before saving', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+        mockSaveCityGuide.mockResolvedValue({ id: 1 });
+
+        await saveCityGuideAction({
+            ...sampleGuide,
+            city: '  Paris ',
+            highlights: [' Eiffel Tower ']
+        });
+
+        expect(mockSaveCityGuide).toHaveBeenCalledWith(expect.objectContaining({
+            city: 'Paris',
+            highlights: ['Eiffel Tower']
+        }));
+    });
 });
 
 describe('deleteCityGuideAction authorization and execution', () => {
@@ -205,6 +221,18 @@ describe('searchFlightsAction', () => {
         });
         expect(result).toBe(flights);
     });
+
+    it('rejects malformed and oversized searches before generation or database access', async () => {
+        await expect(searchFlightsAction('Seattle, USA', 'Detroit, USA', '06/25/2026'))
+            .resolves.toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } });
+        await expect(searchFlightsAction('x'.repeat(121), 'Detroit, USA', '2026-06-25'))
+            .resolves.toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } });
+        await expect(searchFlightsAction('Seattle, USA', 'Detroit, USA', false as any))
+            .resolves.toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } });
+
+        expect(mockGenerateFlightsForDate).not.toHaveBeenCalled();
+        expect(mockedFlightFindMany).not.toHaveBeenCalled();
+    });
 });
 
 describe('getFlightRoutesAction', () => {
@@ -241,9 +269,19 @@ describe('bookFlightAction', () => {
             to: 'B'
         });
 
-        const result = await bookFlightAction({ flightId: 42, totalPrice: '$200' });
+        const passengers = [{
+            firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: '1990-01-01',
+            passportNumber: 'AB123456', gender: 'Female', seatNumber: '11A',
+            cabinClass: 'ECONOMY'
+        }];
+        const result = await bookFlightAction({ flightId: 42, totalPrice: '$200', passengers });
 
-        expect(mockBookFlight).toHaveBeenCalledWith({ flightId: 42, userId: 'user-123', totalPrice: '$200' });
+        expect(mockBookFlight).toHaveBeenCalledWith(expect.objectContaining({
+            flightId: 42,
+            userId: 'user-123',
+            totalPrice: '$200',
+            passengers
+        }));
         expect(result).toEqual({ id: 1, flightId: 42, userId: 'user-123' });
 
         expect(mockedNotificationCreate).toHaveBeenCalledWith({
@@ -254,6 +292,31 @@ describe('bookFlightAction', () => {
                 type: 'POINTS'
             }
         });
+    });
+
+    it('rejects oversized passenger arrays before calling the booking service', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { id: 'user-123' } });
+        const passenger = {
+            firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: '1990-01-01',
+            passportNumber: 'AB123456', gender: 'Female', seatNumber: '11A',
+            cabinClass: 'ECONOMY'
+        };
+
+        await expect(bookFlightAction({
+            flightId: 42,
+            passengers: Array.from({ length: 10 }, () => passenger)
+        })).resolves.toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } });
+        expect(mockBookFlight).not.toHaveBeenCalled();
+    });
+
+    it('rejects bookings without passengers before calling the booking service', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { id: 'user-123' } });
+
+        await expect(bookFlightAction({ flightId: 42 } as any)).resolves.toMatchObject({
+            ok: false,
+            error: { code: 'VALIDATION_ERROR', fields: { passengers: expect.any(Array) } }
+        });
+        expect(mockBookFlight).not.toHaveBeenCalled();
     });
 });
 
@@ -294,6 +357,15 @@ describe('toggleFavoriteCityGuideAction', () => {
         });
         expect(result).toEqual({ isFavorite: true });
     });
+
+    it('rejects malformed favorite identifiers before database access', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { id: 'user-123' } });
+
+        await expect(toggleFavoriteCityGuideAction(-1)).resolves.toMatchObject({
+            ok: false, error: { code: 'VALIDATION_ERROR' }
+        });
+        expect(mockedUserFavoriteFindUnique).not.toHaveBeenCalled();
+    });
 });
 
 describe('submitCityGuideReviewAction', () => {
@@ -319,6 +391,14 @@ describe('submitCityGuideReviewAction', () => {
             }
         });
         expect(result).toEqual({ id: 99, userId: 'user-123', cityGuideId: 5, rating: 5, content: 'Great!' });
+    });
+
+    it('rejects oversized review content before database access', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { id: 'user-123' } });
+
+        await expect(submitCityGuideReviewAction(5, 5, 'x'.repeat(2_001)))
+            .resolves.toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } });
+        expect(mockedReviewCreate).not.toHaveBeenCalled();
     });
 });
 
@@ -511,10 +591,21 @@ describe('changeBookingSeatsAction', () => {
         });
         mockTx.booking.findUnique.mockResolvedValue({ status: 'CANCELLED', passengers: [] });
 
-        await expect(changeBookingSeatsAction(1, [])).rejects.toThrow(
+        await expect(changeBookingSeatsAction(1, [
+            { passengerId: 'p-1', seatNumber: '12A' }
+        ])).rejects.toThrow(
             'Seats cannot be changed on a cancelled booking'
         );
         expect(mockTx.passenger.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed seat changes before starting a transaction', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { id: 'user-123', role: 'USER' } });
+
+        await expect(changeBookingSeatsAction(-1, [
+            { passengerId: '', seatNumber: 'not-a-seat' }
+        ])).resolves.toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } });
+        expect((prisma as any).$transaction).not.toHaveBeenCalled();
     });
 });
 
@@ -597,7 +688,13 @@ describe('admin flight schedule actions', () => {
             await expect(saveFlightScheduleAction({
                 ...sampleScheduleInput,
                 seatPattern: ''
-            })).rejects.toThrow('Seat pattern is required.');
+            })).resolves.toMatchObject({
+                ok: false,
+                error: {
+                    code: 'VALIDATION_ERROR',
+                    fields: { seatPattern: ['Seat pattern is required.'] }
+                }
+            });
 
             expect(mockedFlightScheduleCreate).not.toHaveBeenCalled();
         });
@@ -645,6 +742,20 @@ describe('admin flight schedule actions', () => {
                 }
             });
             expect(result).toHaveProperty('id', 1);
+        });
+
+        it('normalizes schedule identifiers before persistence', async () => {
+            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+            mockedFlightScheduleCreate.mockResolvedValue({ id: 1, daysOfWeek: [] });
+
+            await saveFlightScheduleAction({
+                ...sampleScheduleInput,
+                flightNumber: ' aa 101 '
+            });
+
+            expect(mockedFlightScheduleCreate).toHaveBeenCalledWith({
+                data: expect.objectContaining({ flightNumber: 'AA101' })
+            });
         });
 
         it('allows admin to update an existing flight schedule', async () => {
@@ -887,47 +998,56 @@ describe('admin flight schedule actions', () => {
                 // Negative row count
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     firstClassRows: -1
-                })).rejects.toThrow('Row configurations must be non-negative integers.');
+                })).resolves.toMatchObject({
+                    ok: false,
+                    error: { message: 'Row configurations must be non-negative integers.' }
+                });
 
                 // Fractional and empty layouts
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     firstClassRows: 1.5
-                })).rejects.toThrow('Row configurations must be non-negative integers.');
+                })).resolves.toMatchObject({
+                    ok: false,
+                    error: { message: 'Row configurations must be non-negative integers.' }
+                });
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     firstClassRows: 0,
                     businessRows: 0,
                     premiumEconomyRows: 0,
                     economyRows: 0
-                })).rejects.toThrow('At least one seating row is required.');
+                })).resolves.toMatchObject({
+                    ok: false,
+                    error: { message: 'At least one seating row is required.' }
+                });
 
                 // Duplicate seat letters
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     seatPattern: 'ABC-ABC'
-                })).rejects.toThrow('Seat pattern letters must be unique.');
+                })).resolves.toMatchObject({ ok: false, error: { message: 'Seat pattern letters must be unique.' } });
 
                 // No seat letters (only hyphens)
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     seatPattern: '---'
-                })).rejects.toThrow('Seat pattern must contain at least one seat letter.');
+                })).resolves.toMatchObject({ ok: false, error: { message: 'Seat pattern must contain at least one seat letter.' } });
 
                 // Invalid characters
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     seatPattern: 'ABC_DEF'
-                })).rejects.toThrow('Seat pattern must only contain uppercase letters and hyphens.');
+                })).resolves.toMatchObject({ ok: false, error: { message: 'Seat pattern must only contain uppercase letters and hyphens.' } });
 
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     seatPattern: 'ABC--DEF'
-                })).rejects.toThrow('Seat pattern must contain seat-letter groups separated by single hyphens.');
+                })).resolves.toMatchObject({ ok: false, error: { message: 'Seat pattern must contain seat-letter groups separated by single hyphens.' } });
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     seatPattern: ''
-                })).rejects.toThrow('Seat pattern is required.');
+                })).resolves.toMatchObject({ ok: false, error: { message: 'Seat pattern is required.' } });
 
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     economyRows: 101
-                })).rejects.toThrow('Seating layouts cannot exceed 100 total rows.');
+                })).resolves.toMatchObject({ ok: false, error: { message: 'Seating layouts cannot exceed 100 total rows.' } });
                 await expect(generateFlightOccurrencesAction(1, '2026-07-05', '2026-07-10', {
                     seatPattern: 'ABCDEFGHIJKLM'
-                })).rejects.toThrow('Seat patterns cannot exceed 12 seats per row.');
+                })).resolves.toMatchObject({ ok: false, error: { message: 'Seat patterns cannot exceed 12 seats per row.' } });
             });
 
             it('normalizes seat patterns before persisting occurrences', async () => {
@@ -1033,10 +1153,10 @@ describe('admin flight schedule actions', () => {
 
                 await expect(
                     generateFlightOccurrencesAction(1, '07/05/2026', '2026-07-10')
-                ).rejects.toThrow('Dates must use YYYY-MM-DD format.');
+                ).resolves.toMatchObject({ ok: false, error: { message: 'Dates must use YYYY-MM-DD format.' } });
                 await expect(
                     generateFlightOccurrencesAction(1, '2026-01-01', '2027-01-03')
-                ).rejects.toThrow('Date range cannot exceed 366 days.');
+                ).resolves.toMatchObject({ ok: false, error: { message: 'Date range cannot exceed 366 days.' } });
             });
 
             it('does not invalidate seats already assigned to passengers', async () => {

--- a/__tests__/app/api/register.test.ts
+++ b/__tests__/app/api/register.test.ts
@@ -11,8 +11,11 @@ const mockedPrisma = prisma as unknown as {
     user: { findUnique: jest.Mock; create: jest.Mock };
 };
 
-// The handler only calls req.json(); a minimal stub is enough.
-const makeReq = (body: unknown) => ({ json: async () => body }) as any;
+const makeReq = (body: unknown) => new Request('http://localhost/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+});
 
 describe('POST /api/auth/register', () => {
     beforeEach(() => jest.clearAllMocks());
@@ -39,7 +42,61 @@ describe('POST /api/auth/register', () => {
     it('rejects an invalid email', async () => {
         const res = await POST(makeReq({ name: 'Ada', email: 'not-an-email', password: 'password123' }));
         expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+            error: {
+                code: 'VALIDATION_ERROR',
+                fields: { email: ['Enter a valid email address.'] }
+            }
+        });
         expect(mockedPrisma.user.create).not.toHaveBeenCalled();
+    });
+
+    it('normalizes names and email addresses before persistence', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue(null);
+        mockedPrisma.user.create.mockResolvedValue({
+            id: 'u1', name: 'Ada', email: 'ada@example.com', role: 'USER'
+        });
+
+        await POST(makeReq({
+            name: '  Ada  ', email: ' ADA@Example.COM ', password: 'password123'
+        }));
+
+        expect(mockedPrisma.user.findUnique).toHaveBeenCalledWith({
+            where: { email: 'ada@example.com' }
+        });
+        expect(mockedPrisma.user.create).toHaveBeenCalledWith({
+            data: { name: 'Ada', email: 'ada@example.com', password: 'hashed-pw' }
+        });
+    });
+
+    it('rejects oversized registration requests with a structured error', async () => {
+        const res = await POST(makeReq({
+            name: 'A'.repeat(20_000), email: 'ada@example.com', password: 'password123'
+        }));
+
+        expect(res.status).toBe(413);
+        expect(await res.json()).toMatchObject({
+            error: { code: 'VALIDATION_ERROR', message: 'Request is too large.' }
+        });
+        expect(mockedPrisma.user.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed JSON with a structured customer-safe error', async () => {
+        const request = new Request('http://localhost/api/auth/register', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: '{not-json'
+        });
+
+        const res = await POST(request);
+
+        expect(res.status).toBe(400);
+        expect(await res.json()).toMatchObject({
+            error: {
+                code: 'VALIDATION_ERROR',
+                fields: { _root: ['Request body must be valid JSON.'] }
+            }
+        });
     });
 
     it('rejects a too-short password', async () => {
@@ -57,7 +114,8 @@ describe('POST /api/auth/register', () => {
     it('rejects a duplicate user', async () => {
         mockedPrisma.user.findUnique.mockResolvedValue({ id: 'existing' });
         const res = await POST(makeReq({ name: 'Ada', email: 'ada@example.com', password: 'password123' }));
-        expect(res.status).toBe(400);
+        expect(res.status).toBe(409);
+        expect(await res.json()).toMatchObject({ error: { code: 'ACCOUNT_EXISTS' } });
         expect(mockedPrisma.user.create).not.toHaveBeenCalled();
     });
 
@@ -69,9 +127,11 @@ describe('POST /api/auth/register', () => {
         expect(res.status).toBe(500);
         
         const data = await res.json();
-        expect(data.message).toBe('Error registering user');
+        expect(data.error).toMatchObject({
+            code: 'INTERNAL_ERROR',
+            message: 'Unable to create your account right now.'
+        });
         expect(consoleErrorSpy).toHaveBeenCalled();
         consoleErrorSpy.mockRestore();
     });
 });
-

--- a/__tests__/components/BookingCheckoutWizard.test.tsx
+++ b/__tests__/components/BookingCheckoutWizard.test.tsx
@@ -239,6 +239,70 @@ describe('BookingCheckoutWizard', () => {
         });
     });
 
+    it('routes server passenger validation errors back to the associated field', async () => {
+        mockBookFlightAction.mockResolvedValue({
+            ok: false,
+            error: {
+                code: 'VALIDATION_ERROR',
+                message: 'First name is required.',
+                fields: { 'passengers.0.firstName': ['First name is required.'] },
+            },
+        });
+
+        const { container } = render(<BookingCheckoutWizard flight={sampleFlight} occupiedSeats={[]} />);
+        const firstName = screen.getByPlaceholderText('John');
+        fireEvent.change(firstName, { target: { value: 'Bob' } });
+        fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Jones' } });
+        fireEvent.change(container.querySelector('input[type="date"]')!, { target: { value: '1988-12-01' } });
+        fireEvent.change(screen.getByPlaceholderText('A00000000'), { target: { value: 'US9876543' } });
+        fireEvent.click(screen.getByText('Select Seats →'));
+        fireEvent.click(screen.getByTitle('Select Seat 11C'));
+        fireEvent.click(screen.getByText('Billing & Summary →'));
+        fireEvent.change(screen.getByPlaceholderText('4111 2222 3333 4444'), { target: { value: '4111222233334444' } });
+        fireEvent.change(screen.getByPlaceholderText('JOHN DOE'), { target: { value: 'BOB JONES' } });
+        fireEvent.change(screen.getByPlaceholderText('MM/YY'), { target: { value: '12/29' } });
+        fireEvent.change(screen.getByPlaceholderText('123'), { target: { value: '123' } });
+        fireEvent.click(screen.getByRole('button', { name: /Pay \$100 & Book/i }));
+
+        await waitFor(() => expect(screen.getByText('Traveler Information')).toBeInTheDocument());
+        expect(screen.getByRole('alert')).toHaveTextContent('First name is required.');
+        const invalidFirstName = screen.getByPlaceholderText('John');
+        expect(invalidFirstName).toHaveAttribute('aria-invalid', 'true');
+        expect(invalidFirstName).toHaveAccessibleDescription('First name is required.');
+        await waitFor(() => expect(invalidFirstName).toHaveFocus());
+    });
+
+    it('routes server seat validation errors to an accessible passenger target', async () => {
+        mockBookFlightAction.mockResolvedValue({
+            ok: false,
+            error: {
+                code: 'VALIDATION_ERROR',
+                message: 'Seat number is invalid.',
+                fields: { 'passengers.0.seatNumber': ['Seat number is invalid.'] },
+            },
+        });
+
+        const { container } = render(<BookingCheckoutWizard flight={sampleFlight} occupiedSeats={[]} />);
+        fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Bob' } });
+        fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Jones' } });
+        fireEvent.change(container.querySelector('input[type="date"]')!, { target: { value: '1988-12-01' } });
+        fireEvent.change(screen.getByPlaceholderText('A00000000'), { target: { value: 'US9876543' } });
+        fireEvent.click(screen.getByText('Select Seats →'));
+        fireEvent.click(screen.getByTitle('Select Seat 11C'));
+        fireEvent.click(screen.getByText('Billing & Summary →'));
+        fireEvent.change(screen.getByPlaceholderText('4111 2222 3333 4444'), { target: { value: '4111222233334444' } });
+        fireEvent.change(screen.getByPlaceholderText('JOHN DOE'), { target: { value: 'BOB JONES' } });
+        fireEvent.change(screen.getByPlaceholderText('MM/YY'), { target: { value: '12/29' } });
+        fireEvent.change(screen.getByPlaceholderText('123'), { target: { value: '123' } });
+        fireEvent.click(screen.getByRole('button', { name: /Pay \$100 & Book/i }));
+
+        await waitFor(() => expect(screen.getByText('Select Your Seats')).toBeInTheDocument());
+        const passengerTarget = screen.getByRole('button', { name: /Bob Jones.*Seat: 11C/i });
+        expect(passengerTarget).toHaveAttribute('data-invalid', 'true');
+        expect(passengerTarget).toHaveAccessibleDescription('Seat number is invalid.');
+        await waitFor(() => expect(passengerTarget).toHaveFocus());
+    });
+
     describe('Multi-Passenger Coordinated Adjacent Seat Maps', () => {
         const twoPassengersFlight = {
             ...sampleFlight,
@@ -361,10 +425,7 @@ describe('BookingCheckoutWizard', () => {
             fireEvent.click(seat11A);
 
             // Switch active passenger to Passenger 2
-            const passengerListItems = screen.getAllByText(/Class:/);
-            // Click the card for Passenger 2
-            const p2Card = passengerListItems[1].closest('div');
-            fireEvent.click(p2Card!);
+            fireEvent.click(screen.getByRole('button', { name: /Bob Jones.*Seat: Not Chosen/i }));
 
             // Select seat 11C for Passenger 2
             const seat11C = screen.getByTitle('Select Seat 11C');
@@ -376,8 +437,7 @@ describe('BookingCheckoutWizard', () => {
             expect(cards[1].textContent).toContain('Seat: 11C');
 
             // Switch back to Passenger 1
-            const p1Card = passengerListItems[0].closest('div');
-            fireEvent.click(p1Card!);
+            fireEvent.click(screen.getByRole('button', { name: /Alice Smith.*Seat: 11A/i }));
 
             // Click Bob's seat (11C) to swap
             fireEvent.click(screen.getByTitle(/Seat 11C/));

--- a/__tests__/components/ProfileClient.test.tsx
+++ b/__tests__/components/ProfileClient.test.tsx
@@ -253,4 +253,37 @@ describe('ProfileClient interactive dashboard', () => {
             expect(mockRefresh).toHaveBeenCalled();
         });
     });
+
+    it('uses accessible passenger selectors and announces seat validation errors', async () => {
+        mockGetOccupiedSeats.mockResolvedValue([]);
+        mockChangeBookingSeats.mockResolvedValue({
+            ok: false,
+            error: {
+                code: 'VALIDATION_ERROR',
+                message: 'Choose a valid seat.',
+                fields: { 'seatChanges.0.seatNumber': ['Choose a valid seat.'] },
+            },
+        });
+
+        render(
+            <ProfileClient
+                userName="Jane Doe"
+                userAvatar="avatar.png"
+                currentStatus="Gold"
+                currentPoints={4200}
+                bookings={sampleBookings}
+                favorites={[]}
+                reviews={[]}
+                activityData={[]}
+                monthlyHistory={[]}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Change Seats' }));
+        const passengerSelector = await screen.findByRole('button', { name: /Jane Doe.*Seat: 12A/i });
+        expect(passengerSelector).toHaveAttribute('aria-pressed', 'true');
+        fireEvent.click(screen.getByRole('button', { name: 'Save New Seats' }));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Choose a valid seat.');
+    });
 });

--- a/__tests__/components/TravelGuideClient.test.tsx
+++ b/__tests__/components/TravelGuideClient.test.tsx
@@ -131,6 +131,27 @@ describe('TravelGuideClient', () => {
         });
     });
 
+    it('shows the server validation message when a favorite mutation is rejected', async () => {
+        mockToggleFavorite.mockResolvedValue({
+            ok: false,
+            error: {
+                code: 'VALIDATION_ERROR',
+                message: 'City guide was not found.',
+                fields: { cityGuideId: ['City guide was not found.'] },
+            },
+        });
+
+        render(<TravelGuideClient cities={sampleCities} initialFavorites={[]} />);
+        const favoriteButton = screen.getAllByRole('button', { name: '🤍' })[0];
+        fireEvent.click(favoriteButton);
+
+        await waitFor(() => {
+            expect(global.alert).toHaveBeenCalledWith('City guide was not found.');
+            expect(favoriteButton).toHaveTextContent('🤍');
+        });
+        expect(global.alert).not.toHaveBeenCalledWith('Please sign in to save favorites.');
+    });
+
 
 
     it('submits a review successfully and shows alert on error', async () => {

--- a/__tests__/components/UserAuthForm.test.tsx
+++ b/__tests__/components/UserAuthForm.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UserAuthForm from '@/app/login/components/user-auth-form';
+
+jest.mock('next-auth/react', () => ({ signIn: jest.fn() }));
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: jest.fn(), refresh: jest.fn() })
+}));
+
+describe('UserAuthForm registration errors', () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+        global.fetch = jest.fn();
+    });
+
+    it('shows structured server validation errors and associates them with fields', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: false,
+            json: async () => ({
+                error: {
+                    code: 'VALIDATION_ERROR',
+                    message: 'Enter a valid email address.',
+                    fields: { email: ['Enter a valid email address.'] }
+                }
+            })
+        } as Response);
+        render(<UserAuthForm type="signup" />);
+
+        fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Ada' } });
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'bad@example.com' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid email address.');
+        await waitFor(() => {
+            expect(screen.getByLabelText('Email')).toHaveAttribute('aria-invalid', 'true');
+            expect(screen.getByLabelText('Email')).toHaveAttribute(
+                'aria-describedby',
+                'registration-email-error'
+            );
+        });
+    });
+});

--- a/__tests__/components/flightBookingForm.test.tsx
+++ b/__tests__/components/flightBookingForm.test.tsx
@@ -129,6 +129,23 @@ describe('FlightBookingForm', () => {
         expect(screen.queryByText('Available Flights')).not.toBeInTheDocument();
     });
 
+    it('announces structured server search validation errors', async () => {
+        mockSearch.mockResolvedValue({
+            ok: false,
+            error: {
+                code: 'VALIDATION_ERROR',
+                message: 'Departure date is invalid.',
+                fields: { departureDate: ['Departure date is invalid.'] }
+            }
+        });
+
+        renderForm();
+        fireEvent.click(screen.getByText('Find your trip'));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('Departure date is invalid.');
+        expect(screen.queryByText('Available Flights')).not.toBeInTheDocument();
+    });
+
     it('redirects to the book page when "Book Now" is clicked', async () => {
         mockSearch.mockResolvedValue(mockFlights);
 
@@ -143,7 +160,6 @@ describe('FlightBookingForm', () => {
     });
 
     it('handles toggling trip type to one-way, input changes, and error handling', async () => {
-        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         mockSearch.mockRejectedValue(new Error('Search failed'));
         mockBook.mockRejectedValue(new Error('Booking failed'));
 
@@ -164,11 +180,7 @@ describe('FlightBookingForm', () => {
         expect(returnInput).toBeDisabled();
 
         fireEvent.click(screen.getByText('Find your trip'));
-        await waitFor(() => {
-            expect(consoleErrorSpy).toHaveBeenCalled();
-        });
-
-        consoleErrorSpy.mockRestore();
+        expect(await screen.findByRole('alert')).toHaveTextContent('Unable to search for flights right now.');
     });
 
     it('filters out cancelled flights and exposes interactive price, airline and sorting controls', async () => {

--- a/__tests__/components/travelGuideForm.test.tsx
+++ b/__tests__/components/travelGuideForm.test.tsx
@@ -116,6 +116,25 @@ describe('TravelGuideForm', () => {
         });
     });
 
+    it('announces server validation failures as errors rather than success', async () => {
+        mockSave.mockResolvedValue({
+            ok: false,
+            error: {
+                code: 'VALIDATION_ERROR',
+                message: 'City is required.',
+                fields: { city: ['City is required.'] },
+            },
+        });
+
+        render(<TravelGuideForm />);
+        fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+        const alert = await screen.findByRole('alert');
+        expect(alert).toHaveTextContent('City is required.');
+        expect(alert).toHaveClass('text-red-500');
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
     it('supports adding and editing highlights', async () => {
         render(<TravelGuideForm />);
 
@@ -161,4 +180,3 @@ describe('TravelGuideForm', () => {
         global.FileReader = originalFileReader;
     });
 });
-

--- a/__tests__/lib/FlightBookingService.test.ts
+++ b/__tests__/lib/FlightBookingService.test.ts
@@ -28,23 +28,12 @@ describe('FlightBookingService', () => {
         mockTx.$queryRaw.mockReset();
     });
 
-    it('creates a simple booking when no passengers list is provided (backwards compatibility)', async () => {
-        mockTx.flight.findUnique.mockResolvedValue({ id: 7, price: '$350' });
-        mockTx.booking.create.mockResolvedValue({
-            id: 1,
-            flightId: 7,
-            userId: 'u1',
-            totalPrice: '$350',
-            createdAt: new Date('2026-03-01'),
-        });
+    it('rejects a booking without passengers before starting a transaction', async () => {
+        await expect(new FlightBookingService().bookFlight({ flightId: 7, userId: 'u1' } as any))
+            .rejects.toThrow('At least one passenger is required.');
 
-        const result = await new FlightBookingService().bookFlight({ flightId: 7, userId: 'u1' });
-
-        expect(mockTx.flight.findUnique).toHaveBeenCalledWith({ where: { id: 7 } });
-        expect(mockTx.booking.create).toHaveBeenCalledWith({
-            data: { flightId: 7, userId: 'u1', totalPrice: '$350', paymentIntentId: expect.stringContaining('mock_tx_') },
-        });
-        expect(result).toMatchObject({ id: 1, flightId: 7, userId: 'u1', totalPrice: '$350' });
+        expect(prisma.$transaction).not.toHaveBeenCalled();
+        expect(mockTx.booking.create).not.toHaveBeenCalled();
     });
 
     it('creates a detailed booking with passengers and validates seat selections', async () => {

--- a/__tests__/lib/validation.test.ts
+++ b/__tests__/lib/validation.test.ts
@@ -1,0 +1,270 @@
+/** @jest-environment node */
+import {
+    bookingRequestSchema,
+    cityGuideSchema,
+    favoriteSchema,
+    flightBookingServiceSchema,
+    flightStatusSchema,
+    InputValidationError,
+    MAX_MUTATION_BYTES,
+    occurrenceRequestSchema,
+    parseInput,
+    passengerSchema,
+    registrationSchema,
+    reviewSchema,
+    scheduleSchema,
+    searchFlightsSchema,
+    seatChangesSchema
+} from '@/lib/validation';
+
+describe('shared server validation schemas', () => {
+    it('normalizes valid registration input', () => {
+        expect(registrationSchema.parse({
+            name: '  Ada Lovelace  ',
+            email: '  ADA@Example.COM ',
+            password: 'password123'
+        })).toEqual({
+            name: 'Ada Lovelace',
+            email: 'ada@example.com',
+            password: 'password123'
+        });
+    });
+
+    it('rejects malformed and oversized registration input', () => {
+        expect(registrationSchema.safeParse({
+            name: 'A'.repeat(101),
+            email: 'not-an-email',
+            password: 'short'
+        }).success).toBe(false);
+    });
+
+    it('validates and normalizes reviews and favorite identifiers', () => {
+        expect(reviewSchema.parse({ cityGuideId: 3, rating: 5, content: '  Great trip  ' }))
+            .toEqual({ cityGuideId: 3, rating: 5, content: 'Great trip' });
+        expect(reviewSchema.safeParse({ cityGuideId: 0, rating: 6, content: '' }).success)
+            .toBe(false);
+        expect(favoriteSchema.parse({ cityGuideId: 1 })).toEqual({ cityGuideId: 1 });
+        expect(favoriteSchema.safeParse({ cityGuideId: 1.5 }).success).toBe(false);
+    });
+
+    it('enforces city-guide coordinate, text, image, and array limits', () => {
+        expect(cityGuideSchema.parse({
+            city: ' Paris ',
+            country: ' France ',
+            latlong: [48.85, 2.35],
+            description: ' City of light ',
+            highlights: [' Eiffel Tower '],
+            coverImage: null
+        })).toMatchObject({
+            city: 'Paris',
+            country: 'France',
+            description: 'City of light',
+            highlights: ['Eiffel Tower']
+        });
+        expect(cityGuideSchema.safeParse({
+            city: 'Paris',
+            country: 'France',
+            latlong: [91, 2.35],
+            description: 'Description',
+            highlights: Array.from({ length: 21 }, () => 'Highlight')
+        }).success).toBe(false);
+    });
+
+    it('validates schedules and rejects duplicate days or invalid layouts', () => {
+        expect(scheduleSchema.parse({
+            flightNumber: ' aa 101 ',
+            airline: ' Example Air ',
+            from: ' Seattle, USA ',
+            to: ' Detroit, USA ',
+            departureTime: '08:00',
+            returnTime: null,
+            daysOfWeek: [5, 1],
+            price: '$350',
+            firstClassRows: 3,
+            businessRows: 3,
+            premiumEconomyRows: 4,
+            economyRows: 20,
+            seatPattern: ' abc-def '
+        })).toMatchObject({
+            flightNumber: 'AA101',
+            airline: 'Example Air',
+            daysOfWeek: [1, 5],
+            seatPattern: 'ABC-DEF'
+        });
+        expect(scheduleSchema.safeParse({
+            flightNumber: 'AA101', airline: 'Air', from: 'A', to: 'B',
+            departureTime: '08:00', returnTime: null, daysOfWeek: [1, 1], price: '$1'
+        }).success).toBe(false);
+    });
+
+    it('validates passengers, dates, cabins, seats, and booking array limits', () => {
+        const passenger = {
+            firstName: ' Ada ',
+            lastName: ' Lovelace ',
+            dateOfBirth: '1990-01-02',
+            passportNumber: ' ab123456 ',
+            gender: 'Female',
+            seatNumber: '11a',
+            cabinClass: 'ECONOMY'
+        };
+        expect(passengerSchema.parse(passenger)).toMatchObject({
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            passportNumber: 'AB123456',
+            seatNumber: '11A'
+        });
+        expect(passengerSchema.parse({
+            ...passenger,
+            dateOfBirth: '1990-01-02T00:00:00.000Z'
+        }).dateOfBirth).toBe('1990-01-02');
+        expect(passengerSchema.safeParse({
+            ...passenger,
+            dateOfBirth: '1990-01-02Tgarbage'
+        }).success).toBe(false);
+        expect(passengerSchema.safeParse({ ...passenger, dateOfBirth: '2999-01-01' }).success)
+            .toBe(false);
+        expect(bookingRequestSchema.safeParse({
+            flightId: 1,
+            passengers: Array.from({ length: 9 }, () => passenger)
+        }).success).toBe(true);
+        expect(bookingRequestSchema.safeParse({
+            flightId: 1,
+            passengers: Array.from({ length: 10 }, () => passenger)
+        }).success).toBe(false);
+        expect(flightBookingServiceSchema.safeParse({
+            flightId: 1,
+            userId: 'user-1',
+            passengers: [passenger]
+        }).success).toBe(true);
+        expect(flightBookingServiceSchema.safeParse({ flightId: 1, userId: '' }).success)
+            .toBe(false);
+    });
+
+    it('validates occurrence dates, ranges, identifiers, and override shapes', () => {
+        expect(occurrenceRequestSchema.parse({
+            scheduleId: 2,
+            startDate: '2026-07-01',
+            endDate: '2026-07-31',
+            seatingConfig: { economyRows: 22, seatPattern: 'ABC-DEF' }
+        })).toMatchObject({ scheduleId: 2, startDate: '2026-07-01' });
+        expect(occurrenceRequestSchema.safeParse({
+            scheduleId: 0,
+            startDate: '07/01/2026',
+            endDate: '2027-07-31',
+            seatingConfig: { unknown: true }
+        }).success).toBe(false);
+    });
+
+    it('validates seat changes and rejects duplicate passengers or seats', () => {
+        expect(seatChangesSchema.parse({
+            bookingId: 2,
+            seatChanges: [{ passengerId: ' passenger-1 ', seatNumber: '12b' }]
+        })).toEqual({
+            bookingId: 2,
+            seatChanges: [{ passengerId: 'passenger-1', seatNumber: '12B' }]
+        });
+        expect(seatChangesSchema.safeParse({
+            bookingId: 2,
+            seatChanges: [
+                { passengerId: 'p1', seatNumber: '12A' },
+                { passengerId: 'p2', seatNumber: '12A' }
+            ]
+        }).success).toBe(false);
+    });
+
+    it('throws structured customer-safe errors and enforces mutation byte limits', () => {
+        expect(() => parseInput(favoriteSchema, { cityGuideId: -1 })).toThrow(InputValidationError);
+        try {
+            parseInput(favoriteSchema, { cityGuideId: -1 });
+        } catch (error) {
+            expect(error).toMatchObject({
+                code: 'VALIDATION_ERROR'
+            });
+            expect((error as InputValidationError).fields).toHaveProperty('cityGuideId');
+        }
+
+        expect(() => parseInput(
+            cityGuideSchema,
+            { padding: 'x'.repeat(MAX_MUTATION_BYTES) }
+        )).toThrow('Request is too large.');
+    });
+
+    it('covers exact registration, review, and search boundaries', () => {
+        expect(registrationSchema.safeParse({
+            name: 'N'.repeat(100), email: 'a@example.com', password: 'p'.repeat(128)
+        }).success).toBe(true);
+        expect(registrationSchema.safeParse({
+            name: 'N'.repeat(101), email: 'a@example.com', password: 'p'.repeat(129)
+        }).success).toBe(false);
+        expect(registrationSchema.safeParse({
+            name: 'Ada', email: 'a@example.com', password: 'password', extra: true
+        }).success).toBe(false);
+
+        expect(reviewSchema.safeParse({ cityGuideId: 1, rating: 1, content: 'x'.repeat(2_000) }).success).toBe(true);
+        expect(reviewSchema.safeParse({ cityGuideId: 1, rating: 5, content: 'x'.repeat(2_001) }).success).toBe(false);
+        expect(reviewSchema.safeParse({ cityGuideId: '1', rating: 3, content: 'Review' }).success).toBe(false);
+
+        expect(searchFlightsSchema.parse({
+            from: ` ${'A'.repeat(120)} `, to: ' B ', departureDate: '2026-06-25'
+        })).toEqual({ from: 'A'.repeat(120), to: 'B', departureDate: '2026-06-25' });
+        expect(searchFlightsSchema.safeParse({ from: 'A'.repeat(121), to: '', departureDate: '06/25/2026' }).success).toBe(false);
+        expect(searchFlightsSchema.safeParse({ from: 'A', to: 'B', unknown: true }).success).toBe(false);
+    });
+
+    it('covers exact city-guide and schedule boundaries', () => {
+        const imagePrefix = 'data:image/png;base64,';
+        const boundaryGuide = {
+            city: 'C'.repeat(100),
+            country: 'K'.repeat(100),
+            latlong: [-90, 180],
+            description: 'D'.repeat(5_000),
+            highlights: Array.from({ length: 20 }, () => 'H'.repeat(200)),
+            coverImage: imagePrefix + 'a'.repeat(750_000 - imagePrefix.length)
+        };
+        expect(cityGuideSchema.safeParse(boundaryGuide).success).toBe(true);
+        expect(cityGuideSchema.safeParse({ ...boundaryGuide, description: 'D'.repeat(5_001) }).success).toBe(false);
+        expect(cityGuideSchema.safeParse({ ...boundaryGuide, highlights: [...boundaryGuide.highlights, 'extra'] }).success).toBe(false);
+        expect(cityGuideSchema.safeParse({ ...boundaryGuide, coverImage: boundaryGuide.coverImage + 'a' }).success).toBe(false);
+        expect(cityGuideSchema.safeParse({ ...boundaryGuide, latlong: ['north', 180] }).success).toBe(false);
+
+        const boundarySchedule = {
+            flightNumber: 'AB12345678', airline: 'A'.repeat(120), from: 'F'.repeat(120), to: 'T'.repeat(120),
+            departureTime: '23:59', returnTime: '00:00', daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+            price: '$999999.99', firstClassRows: 0, businessRows: 0,
+            premiumEconomyRows: 0, economyRows: 1, seatPattern: 'ABCDEFGHIJKL'
+        };
+        expect(scheduleSchema.safeParse(boundarySchedule).success).toBe(true);
+        expect(scheduleSchema.safeParse({ ...boundarySchedule, airline: 'A'.repeat(121) }).success).toBe(false);
+        expect(scheduleSchema.safeParse({ ...boundarySchedule, daysOfWeek: [...boundarySchedule.daysOfWeek, 0] }).success).toBe(false);
+        expect(scheduleSchema.safeParse({ ...boundarySchedule, seatPattern: 'ABCDEFGHIJKLM' }).success).toBe(false);
+        expect(scheduleSchema.safeParse({ ...boundarySchedule, departureTime: 1200 }).success).toBe(false);
+    });
+
+    it('covers exact passenger, booking, seat-change, occurrence, and enum boundaries', () => {
+        const passenger = {
+            firstName: 'F'.repeat(100), lastName: 'L'.repeat(100), dateOfBirth: '1900-01-01',
+            passportNumber: 'P'.repeat(32), gender: 'Other', seatNumber: '999A', cabinClass: 'FIRST'
+        };
+        expect(passengerSchema.safeParse(passenger).success).toBe(true);
+        expect(passengerSchema.safeParse({ ...passenger, firstName: 'F'.repeat(101) }).success).toBe(false);
+        expect(passengerSchema.safeParse({ ...passenger, gender: 'Unknown' }).success).toBe(false);
+        expect(passengerSchema.safeParse({ ...passenger, extra: true }).success).toBe(false);
+
+        const passengers = Array.from({ length: 9 }, (_, index) => ({
+            ...passenger, passportNumber: `P${index}`, seatNumber: `${index + 1}A`
+        }));
+        expect(bookingRequestSchema.safeParse({ flightId: 1, passengers }).success).toBe(true);
+        expect(bookingRequestSchema.safeParse({ flightId: 1, passengers: [] }).success).toBe(false);
+        expect(bookingRequestSchema.safeParse({ flightId: 1, passengers: [...passengers, passenger] }).success).toBe(false);
+
+        const seatChanges = Array.from({ length: 9 }, (_, index) => ({ passengerId: `p${index}`, seatNumber: `${index + 1}A` }));
+        expect(seatChangesSchema.safeParse({ bookingId: 1, seatChanges }).success).toBe(true);
+        expect(seatChangesSchema.safeParse({ bookingId: 1, seatChanges: [...seatChanges, { passengerId: 'p9', seatNumber: '10A' }] }).success).toBe(false);
+        expect(seatChangesSchema.safeParse({ bookingId: '1', seatChanges }).success).toBe(false);
+
+        expect(occurrenceRequestSchema.safeParse({ scheduleId: 1, startDate: '2026-01-01', endDate: '2027-01-02' }).success).toBe(true);
+        expect(occurrenceRequestSchema.safeParse({ scheduleId: 1, startDate: '2026-01-01', endDate: '2027-01-03' }).success).toBe(false);
+        expect(flightStatusSchema.safeParse('CANCELLED').success).toBe(true);
+        expect(flightStatusSchema.safeParse('BOARDING').success).toBe(false);
+    });
+});

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -11,6 +11,22 @@ import { prisma } from '@/lib/prisma';
 import { assertSeatAvailableForCabin, validateSeatingLayout } from '@/lib/seatLayout';
 import { lockFlightForUpdate } from '@/lib/flightLock';
 import { updateFlightSeatingLayout } from '@/lib/FlightSeatLayoutService';
+import { actionValidationFailure } from '@/lib/actionResult';
+import {
+    bookingRequestSchema,
+    cityGuideSchema,
+    favoriteSchema,
+    flightStatusSchema,
+    numericIdSchema,
+    occurrenceRequestSchema,
+    parseActionInput,
+    parseInput,
+    reviewSchema,
+    scheduleSchema,
+    searchFlightsSchema,
+    seatChangesSchema,
+    stringIdSchema
+} from '@/lib/validation';
 
 const travelGuideService = new TravelGuideService();
 const flightBookingService = new FlightBookingService();
@@ -19,7 +35,9 @@ export async function saveCityGuideAction(cityGuide: CityGuide) {
     const session = await getServerSession(authOptions);
     if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
 
-    const result = await travelGuideService.saveCityGuide(cityGuide);
+    const parsed = parseActionInput(cityGuideSchema, cityGuide);
+    if (!parsed.ok) return parsed;
+    const result = await travelGuideService.saveCityGuide(parsed.data as CityGuide);
     revalidatePath('/admin/travelguide');
     revalidatePath('/travelguide');
     return result;
@@ -29,6 +47,9 @@ export async function deleteCityGuideAction(cityGuideId: number) {
     const session = await getServerSession(authOptions);
     if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
 
+    const parsed = parseActionInput(numericIdSchema, cityGuideId);
+    if (!parsed.ok) return parsed;
+    cityGuideId = parsed.data;
     await prisma.cityGuide.delete({
         where: { id: cityGuideId }
     });
@@ -37,6 +58,16 @@ export async function deleteCityGuideAction(cityGuideId: number) {
 }
 
 export async function searchFlightsAction(from: string, to: string, departureDateStr?: string) {
+    const parsed = parseActionInput(searchFlightsSchema, {
+        from,
+        to,
+        departureDate: departureDateStr === '' || departureDateStr === undefined
+            ? undefined
+            : departureDateStr
+    });
+    if (!parsed.ok) return parsed;
+    ({ from, to, departureDate: departureDateStr } = parsed.data);
+
     if (!departureDateStr) {
         return await prisma.flight.findMany({
             where: { from, to },
@@ -78,12 +109,15 @@ export async function getFlightRoutesAction() {
 export async function bookFlightAction(bookingData: { 
     flightId: number; 
     totalPrice?: string; 
-    passengers?: PassengerInput[]; 
+    passengers: PassengerInput[];
     paymentIntentId?: string; 
 }) {
     const session = await getServerSession(authOptions);
     const userId = session?.user?.id;
     if (!userId) throw new Error("Unauthorized");
+    const parsed = parseActionInput(bookingRequestSchema, bookingData);
+    if (!parsed.ok) return parsed;
+    bookingData = parsed.data as typeof bookingData;
 
     const result = await flightBookingService.bookFlight({
         flightId: bookingData.flightId,
@@ -116,6 +150,7 @@ export async function bookFlightAction(bookingData: {
 }
 
 export async function getOccupiedSeatsAction(flightId: number) {
+    flightId = parseInput(numericIdSchema, flightId);
     const passengers = await prisma.passenger.findMany({
         where: {
             booking: {
@@ -135,6 +170,9 @@ export async function toggleFavoriteCityGuideAction(cityGuideId: number) {
     const userId = session?.user?.id;
     if (!userId) throw new Error("Unauthorized");
 
+    const parsed = parseActionInput(favoriteSchema, { cityGuideId });
+    if (!parsed.ok) return parsed;
+    cityGuideId = parsed.data.cityGuideId;
     const existing = await prisma.userFavorite.findUnique({
         where: { userId_cityGuideId: { userId, cityGuideId } }
     });
@@ -157,12 +195,15 @@ export async function submitCityGuideReviewAction(cityGuideId: number, rating: n
     const userId = session?.user?.id;
     if (!userId) throw new Error("Unauthorized");
 
+    const parsed = parseActionInput(reviewSchema, { cityGuideId, rating, content });
+    if (!parsed.ok) return parsed;
+    const validated = parsed.data;
     return await prisma.review.create({
         data: {
             userId,
-            cityGuideId,
-            rating,
-            content
+            cityGuideId: validated.cityGuideId,
+            rating: validated.rating,
+            content: validated.content
         }
     });
 }
@@ -172,6 +213,9 @@ export async function cancelBookingAction(bookingId: number) {
     const userId = session?.user?.id;
     if (!userId) throw new Error("Unauthorized");
 
+    const parsed = parseActionInput(numericIdSchema, bookingId);
+    if (!parsed.ok) return parsed;
+    bookingId = parsed.data;
     const booking = await prisma.booking.findUnique({
         where: { id: bookingId },
         include: { flight: true }
@@ -238,6 +282,10 @@ export async function changeBookingSeatsAction(
     const session = await getServerSession(authOptions);
     const userId = session?.user?.id;
     if (!userId) throw new Error("Unauthorized");
+    const parsed = parseActionInput(seatChangesSchema, { bookingId, seatChanges });
+    if (!parsed.ok) return parsed;
+    bookingId = parsed.data.bookingId;
+    seatChanges = parsed.data.seatChanges;
 
     const booking = await prisma.booking.findUnique({
         where: { id: bookingId },
@@ -319,6 +367,9 @@ export async function deleteReviewAction(reviewId: string) {
     const userId = session?.user?.id;
     if (!userId) throw new Error("Unauthorized");
 
+    const parsed = parseActionInput(stringIdSchema, reviewId);
+    if (!parsed.ok) return parsed;
+    reviewId = parsed.data;
     const review = await prisma.review.findUnique({
         where: { id: reviewId }
     });
@@ -356,6 +407,9 @@ export async function saveFlightScheduleAction(data: {
 }) {
     const session = await getServerSession(authOptions);
     if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
+    const parsed = parseActionInput(scheduleSchema, data);
+    if (!parsed.ok) return parsed;
+    data = parsed.data as typeof data;
 
     // Server-side validation
     if (!data.flightNumber || !data.airline || !data.from || !data.to || !data.departureTime || !data.price) {
@@ -381,13 +435,21 @@ export async function saveFlightScheduleAction(data: {
     const economyRows = data.economyRows !== undefined && data.economyRows !== null ? Number(data.economyRows) : 20;
     const seatPattern = data.seatPattern ?? "ABC-DEF";
 
-    const normalizedSeatPattern = validateSeatingLayout(
-        firstClassRows,
-        businessRows,
-        premiumEconomyRows,
-        economyRows,
-        seatPattern
-    );
+    let normalizedSeatPattern: string;
+    try {
+        normalizedSeatPattern = validateSeatingLayout(
+            firstClassRows,
+            businessRows,
+            premiumEconomyRows,
+            economyRows,
+            seatPattern
+        );
+    } catch (error) {
+        return actionValidationFailure(
+            error instanceof Error ? error.message : 'Seating layout is invalid.',
+            'seatingConfig'
+        );
+    }
 
     let savedSchedule;
     if (data.id) {
@@ -506,6 +568,17 @@ export async function generateFlightOccurrencesAction(
 ) {
     const session = await getServerSession(authOptions);
     if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
+    const parsed = parseActionInput(occurrenceRequestSchema, {
+        scheduleId,
+        startDate: startDateStr,
+        endDate: endDateStr,
+        seatingConfig
+    });
+    if (!parsed.ok) return parsed;
+    scheduleId = parsed.data.scheduleId;
+    startDateStr = parsed.data.startDate;
+    endDateStr = parsed.data.endDate;
+    seatingConfig = parsed.data.seatingConfig;
 
     const schedule = await prisma.flightSchedule.findUnique({
         where: { id: scheduleId }
@@ -542,13 +615,21 @@ export async function generateFlightOccurrencesAction(
         ? seatingConfig.seatPattern
         : (schedule.seatPattern ?? "ABC-DEF");
 
-    const normalizedSeatPattern = validateSeatingLayout(
-        firstClassRows,
-        businessRows,
-        premiumEconomyRows,
-        economyRows,
-        seatPattern
-    );
+    let normalizedSeatPattern: string;
+    try {
+        normalizedSeatPattern = validateSeatingLayout(
+            firstClassRows,
+            businessRows,
+            premiumEconomyRows,
+            economyRows,
+            seatPattern
+        );
+    } catch (error) {
+        return actionValidationFailure(
+            error instanceof Error ? error.message : 'Seating layout is invalid.',
+            'seatingConfig'
+        );
+    }
 
     const current = new Date(start);
     let occurrencesCreated = 0;
@@ -652,6 +733,9 @@ export async function deleteFlightScheduleAction(scheduleId: number) {
     const session = await getServerSession(authOptions);
     if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
 
+    const parsed = parseActionInput(numericIdSchema, scheduleId);
+    if (!parsed.ok) return parsed;
+    scheduleId = parsed.data;
     await prisma.flightSchedule.delete({
         where: { id: scheduleId }
     });
@@ -665,6 +749,12 @@ export async function updateFlightStatusAction(flightId: number, status: 'ON_TIM
     const session = await getServerSession(authOptions);
     if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
 
+    const parsedId = parseActionInput(numericIdSchema, flightId);
+    if (!parsedId.ok) return parsedId;
+    const parsedStatus = parseActionInput(flightStatusSchema, status);
+    if (!parsedStatus.ok) return parsedStatus;
+    flightId = parsedId.data;
+    status = parsedStatus.data;
     const updated = await prisma.flight.update({
         where: { id: flightId },
         data: { status }
@@ -717,6 +807,9 @@ export async function markNotificationAsReadAction(id: string) {
     const userId = session?.user?.id;
     if (!userId) throw new Error("Unauthorized");
 
+    const parsed = parseActionInput(stringIdSchema, id);
+    if (!parsed.ok) return parsed;
+    id = parsed.data;
     const notif = await prisma.notification.findUnique({
         where: { id }
     });

--- a/app/admin/flights/DeleteScheduleButton.tsx
+++ b/app/admin/flights/DeleteScheduleButton.tsx
@@ -3,6 +3,7 @@
 import React, { useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { deleteFlightScheduleAction } from '@/app/actions';
+import { isActionValidationFailure } from '@/lib/actionResult';
 
 export default function DeleteScheduleButton({ id }: { id: number }) {
     const router = useRouter();
@@ -15,7 +16,11 @@ export default function DeleteScheduleButton({ id }: { id: number }) {
 
         startTransition(async () => {
             try {
-                await deleteFlightScheduleAction(id);
+                const result = await deleteFlightScheduleAction(id);
+                if (isActionValidationFailure(result)) {
+                    alert(result.error.message);
+                    return;
+                }
                 router.refresh();
             } catch (err) {
                 const message = err instanceof Error ? err.message : 'Failed to delete schedule.';

--- a/app/admin/flights/FlightStatusSelector.tsx
+++ b/app/admin/flights/FlightStatusSelector.tsx
@@ -3,6 +3,7 @@
 import React, { useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { updateFlightStatusAction } from '@/app/actions';
+import { isActionValidationFailure } from '@/lib/actionResult';
 
 export default function FlightStatusSelector({ id, currentStatus }: { id: number, currentStatus: string }) {
     const router = useRouter();
@@ -12,7 +13,11 @@ export default function FlightStatusSelector({ id, currentStatus }: { id: number
         const nextStatus = e.target.value as 'ON_TIME' | 'DELAYED' | 'CANCELLED';
         startTransition(async () => {
             try {
-                await updateFlightStatusAction(id, nextStatus);
+                const result = await updateFlightStatusAction(id, nextStatus);
+                if (isActionValidationFailure(result)) {
+                    alert(result.error.message);
+                    return;
+                }
                 router.refresh();
             } catch (err) {
                 const message = err instanceof Error ? err.message : 'Failed to update flight status.';

--- a/app/admin/travelguide/DeleteGuideButton.tsx
+++ b/app/admin/travelguide/DeleteGuideButton.tsx
@@ -1,6 +1,7 @@
 "use client"
 import React, { useTransition } from 'react';
 import { deleteCityGuideAction } from '@/app/actions';
+import { isActionValidationFailure } from '@/lib/actionResult';
 
 export default function DeleteGuideButton({ id }: { id: number }) {
     const [isPending, startTransition] = useTransition();
@@ -8,7 +9,8 @@ export default function DeleteGuideButton({ id }: { id: number }) {
     const handleDelete = () => {
         if (confirm('Are you sure you want to delete this guide?')) {
             startTransition(async () => {
-                await deleteCityGuideAction(id);
+                const result = await deleteCityGuideAction(id);
+                if (isActionValidationFailure(result)) alert(result.error.message);
             });
         }
     };

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,35 +1,34 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import bcrypt from 'bcryptjs';
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const MIN_PASSWORD_LENGTH = 8;
+import {
+    InputValidationError,
+    MAX_REGISTRATION_BYTES,
+    parseJsonRequest,
+    registrationSchema,
+    validationErrorPayload
+} from '@/lib/validation';
 
 export async function POST(req: Request) {
     try {
-        const { name, email, password } = await req.json();
-
-        if (!name || !email || !password) {
-            return NextResponse.json({ message: 'Missing fields' }, { status: 400 });
-        }
-
-        if (typeof email !== 'string' || !EMAIL_REGEX.test(email)) {
-            return NextResponse.json({ message: 'Invalid email address' }, { status: 400 });
-        }
-
-        if (typeof password !== 'string' || password.length < MIN_PASSWORD_LENGTH) {
-            return NextResponse.json(
-                { message: `Password must be at least ${MIN_PASSWORD_LENGTH} characters` },
-                { status: 400 }
-            );
-        }
+        const { name, email, password } = await parseJsonRequest(
+            req,
+            registrationSchema,
+            MAX_REGISTRATION_BYTES
+        );
 
         const existingUser = await prisma.user.findUnique({
             where: { email },
         });
 
         if (existingUser) {
-            return NextResponse.json({ message: 'User already exists' }, { status: 400 });
+            return NextResponse.json({
+                error: {
+                    code: 'ACCOUNT_EXISTS',
+                    message: 'An account already exists for that email address.',
+                    fields: { email: ['Use a different email address or sign in.'] }
+                }
+            }, { status: 409 });
         }
 
         const hashedPassword = await bcrypt.hash(password, 10);
@@ -50,8 +49,20 @@ export async function POST(req: Request) {
             { status: 201 }
         );
     } catch (error) {
+        if (error instanceof InputValidationError) {
+            return NextResponse.json(
+                validationErrorPayload(error),
+                { status: error.message === 'Request is too large.' ? 413 : 400 }
+            );
+        }
         // Log server-side; do not leak internal error details to the client.
         console.error('Error registering user:', error);
-        return NextResponse.json({ message: 'Error registering user' }, { status: 500 });
+        return NextResponse.json({
+            error: {
+                code: 'INTERNAL_ERROR',
+                message: 'Unable to create your account right now.',
+                fields: {}
+            }
+        }, { status: 500 });
     }
 }

--- a/app/login/components/user-auth-form.tsx
+++ b/app/login/components/user-auth-form.tsx
@@ -10,17 +10,20 @@ interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export default function UserAuthForm({ className, type, ...props }: UserAuthFormProps) {
     const [isLoading, setIsLoading] = React.useState<boolean>(false);
+    const [formError, setFormError] = React.useState<{
+        message: string;
+        fields: Record<string, string[]>;
+    } | null>(null);
     const router = useRouter();
 
-    async function onSubmit(event: React.SyntheticEvent) {
+    async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
         setIsLoading(true);
-
-        const target = event.target as typeof event.target & {
-            email: { value: string };
-            password: { value: string };
-            name?: { value: string };
-        };
+        setFormError(null);
+        const formData = new FormData(event.currentTarget);
+        const email = String(formData.get('email') ?? '');
+        const password = String(formData.get('password') ?? '');
+        const name = String(formData.get('name') ?? '');
 
         if (type === "signup") {
             try {
@@ -30,21 +33,26 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                         "Content-Type": "application/json",
                     },
                     body: JSON.stringify({
-                        name: target.name?.value,
-                        email: target.email.value,
-                        password: target.password.value,
+                        name,
+                        email,
+                        password,
                     }),
                 });
 
                 if (!response.ok) {
-                    throw new Error("Registration failed");
+                    const payload = await response.json().catch(() => null);
+                    setFormError({
+                        message: payload?.error?.message ?? 'Unable to create your account.',
+                        fields: payload?.error?.fields ?? {}
+                    });
+                    return;
                 }
 
                 // Auto sign-in after registration
                 const result = await signIn("credentials", {
                     redirect: false,
-                    email: target.email.value,
-                    password: target.password.value,
+                    email,
+                    password,
                 });
 
                 if (result?.error) {
@@ -56,6 +64,7 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
 
             } catch (error) {
                 console.error(error);
+                setFormError({ message: 'Unable to create your account.', fields: {} });
             } finally {
                 setIsLoading(false);
             }
@@ -63,8 +72,8 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
             // Handle login
             const result = await signIn("credentials", {
                 redirect: false,
-                email: target.email.value,
-                password: target.password.value,
+                email,
+                password,
             });
 
             if (result?.error) {
@@ -88,12 +97,15 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                             </label>
                             <input
                                 id="name"
+                                name="name"
                                 placeholder="John Doe"
                                 type="text"
                                 autoCapitalize="words"
                                 autoComplete="name"
                                 autoCorrect="off"
                                 disabled={isLoading}
+                                aria-invalid={Boolean(formError?.fields.name)}
+                                aria-describedby={formError?.fields.name ? 'registration-name-error' : undefined}
                                 required
                                 style={{
                                     display: "flex",
@@ -108,6 +120,11 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                                     transition: "color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out",
                                 }}
                             />
+                            {formError?.fields.name && (
+                                <p id="registration-name-error" style={{ color: '#f87171', fontSize: '0.8rem', margin: 0 }}>
+                                    {formError.fields.name[0]}
+                                </p>
+                            )}
                         </div>
                     )}
                     <div className="grid gap-1">
@@ -116,12 +133,15 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                         </label>
                         <input
                             id="email"
+                            name="email"
                             placeholder="name@example.com"
                             type="email"
                             autoCapitalize="none"
                             autoComplete="email"
                             autoCorrect="off"
                             disabled={isLoading}
+                            aria-invalid={Boolean(formError?.fields.email)}
+                            aria-describedby={formError?.fields.email ? 'registration-email-error' : undefined}
                             required
                             style={{
                                 display: "flex",
@@ -136,6 +156,11 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                                 transition: "color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out",
                             }}
                         />
+                        {formError?.fields.email && (
+                            <p id="registration-email-error" style={{ color: '#f87171', fontSize: '0.8rem', margin: 0 }}>
+                                {formError.fields.email[0]}
+                            </p>
+                        )}
                     </div>
                     <div className="grid gap-1">
                         <label className="sr-only" htmlFor="password">
@@ -143,12 +168,15 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                         </label>
                         <input
                             id="password"
+                            name="password"
                             placeholder="Password"
                             type="password"
                             autoCapitalize="none"
                             autoComplete="current-password"
                             autoCorrect="off"
                             disabled={isLoading}
+                            aria-invalid={Boolean(formError?.fields.password)}
+                            aria-describedby={formError?.fields.password ? 'registration-password-error' : undefined}
                             required
                             style={{
                                 display: "flex",
@@ -163,7 +191,17 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                                 transition: "color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out",
                             }}
                         />
+                        {formError?.fields.password && (
+                            <p id="registration-password-error" style={{ color: '#f87171', fontSize: '0.8rem', margin: 0 }}>
+                                {formError.fields.password[0]}
+                            </p>
+                        )}
                     </div>
+                    {formError && (
+                        <div role="alert" style={{ color: '#f87171', fontSize: '0.875rem' }}>
+                            {formError.message}
+                        </div>
+                    )}
                     <button disabled={isLoading} style={{
                         display: "inline-flex",
                         alignItems: "center",

--- a/components/ui/BookingCheckoutWizard.tsx
+++ b/components/ui/BookingCheckoutWizard.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { PassengerInput } from '@/lib/FlightBookingService';
 import { bookFlightAction } from '@/app/actions';
+import { isActionValidationFailure } from '@/lib/actionResult';
 
 interface Flight {
     id: number;
@@ -77,6 +78,7 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
     const [paymentCard, setPaymentCard] = useState({ number: '', name: '', expiry: '', cvv: '' });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [serverFieldErrors, setServerFieldErrors] = useState<Record<string, string[]>>({});
     const [bookingResult, setBookingResult] = useState<{ id: number; paymentIntentId: string } | null>(null);
     const [autoAllocateGroup, setAutoAllocateGroup] = useState<boolean>(true);
     const [hoveredSuggestedSeats, setHoveredSuggestedSeats] = useState<string[]>([]);
@@ -123,7 +125,17 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
             updated[index].seatNumber = '';
         }
         setPassengers(updated);
+        const fieldPath = `passengers.${index}.${field}`;
+        setServerFieldErrors(current => {
+            if (!current[fieldPath]) return current;
+            const next = { ...current };
+            delete next[fieldPath];
+            return next;
+        });
     };
+
+    const getPassengerFieldError = (index: number, field: keyof PassengerFormState) =>
+        serverFieldErrors[`passengers.${index}.${field}`]?.[0];
 
     const validateStep1 = () => {
         for (let i = 0; i < passengers.length; i++) {
@@ -394,6 +406,9 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
 
     const handleSeatClick = (seat: string) => {
         const cabinClass = passengers[activePassengerIndex]?.cabinClass || 'ECONOMY';
+        setServerFieldErrors(current => Object.fromEntries(
+            Object.entries(current).filter(([field]) => !/^passengers\.\d+\.seatNumber$/.test(field))
+        ));
 
         if (autoAllocateGroup && passengers.length > 1) {
             const sameClassPassengerIndices = passengers
@@ -454,6 +469,7 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
         if (!validateStep3()) return;
         setIsSubmitting(true);
         setErrorMessage(null);
+        setServerFieldErrors({});
 
         try {
             const formattedPassengers: PassengerInput[] = passengers.map(p => ({
@@ -472,6 +488,25 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                 passengers: formattedPassengers,
                 paymentIntentId: `ch_${Math.random().toString(36).substr(2, 9)}`
             });
+
+            if (isActionValidationFailure(result)) {
+                setErrorMessage(result.error.message);
+                setServerFieldErrors(result.error.fields);
+                const firstFieldPath = Object.keys(result.error.fields)[0];
+                const passengerMatch = /^passengers\.(\d+)\.(\w+)$/.exec(firstFieldPath || '');
+                if (passengerMatch) {
+                    const passengerIndex = Number(passengerMatch[1]);
+                    setActivePassengerIndex(passengerIndex);
+                    setStep(passengerMatch[2] === 'seatNumber' ? 2 : 1);
+                    setTimeout(() => {
+                        const field = document.querySelector<HTMLElement>(
+                            `[data-validation-path="${firstFieldPath}"]`
+                        );
+                        field?.focus();
+                    }, 0);
+                }
+                return;
+            }
 
             setBookingResult({
                 id: result.id,
@@ -520,7 +555,7 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
             </div>
 
             {errorMessage && (
-                <div style={{ backgroundColor: 'rgba(239, 68, 68, 0.15)', color: '#f87171', border: '1px solid rgba(239, 68, 68, 0.3)', padding: '12px', borderRadius: '8px', marginBottom: '1.5rem' }}>
+                <div role="alert" style={{ backgroundColor: 'rgba(239, 68, 68, 0.15)', color: '#f87171', border: '1px solid rgba(239, 68, 68, 0.3)', padding: '12px', borderRadius: '8px', marginBottom: '1.5rem' }}>
                     ⚠️ {errorMessage}
                 </div>
             )}
@@ -563,8 +598,12 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                             value={passenger.firstName}
                                             onChange={(e) => handlePassengerChange(index, 'firstName', e.target.value)}
                                             placeholder="John"
+                                            data-validation-path={`passengers.${index}.firstName`}
+                                            aria-invalid={Boolean(getPassengerFieldError(index, 'firstName'))}
+                                            aria-describedby={getPassengerFieldError(index, 'firstName') ? `passenger-${index}-firstName-error` : undefined}
                                             style={{ width: '100%', padding: '8px 12px', borderRadius: '6px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#fff' }}
                                         />
+                                        {getPassengerFieldError(index, 'firstName') && <div id={`passenger-${index}-firstName-error`} style={{ color: '#f87171', fontSize: '0.8rem', marginTop: '4px' }}>{getPassengerFieldError(index, 'firstName')}</div>}
                                     </div>
                                     <div>
                                         <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '4px', color: 'rgba(255,255,255,0.7)' }}>Last Name</label>
@@ -573,8 +612,12 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                             value={passenger.lastName}
                                             onChange={(e) => handlePassengerChange(index, 'lastName', e.target.value)}
                                             placeholder="Doe"
+                                            data-validation-path={`passengers.${index}.lastName`}
+                                            aria-invalid={Boolean(getPassengerFieldError(index, 'lastName'))}
+                                            aria-describedby={getPassengerFieldError(index, 'lastName') ? `passenger-${index}-lastName-error` : undefined}
                                             style={{ width: '100%', padding: '8px 12px', borderRadius: '6px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#fff' }}
                                         />
+                                        {getPassengerFieldError(index, 'lastName') && <div id={`passenger-${index}-lastName-error`} style={{ color: '#f87171', fontSize: '0.8rem', marginTop: '4px' }}>{getPassengerFieldError(index, 'lastName')}</div>}
                                     </div>
                                 </div>
 
@@ -585,8 +628,12 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                             type="date"
                                             value={passenger.dateOfBirth}
                                             onChange={(e) => handlePassengerChange(index, 'dateOfBirth', e.target.value)}
+                                            data-validation-path={`passengers.${index}.dateOfBirth`}
+                                            aria-invalid={Boolean(getPassengerFieldError(index, 'dateOfBirth'))}
+                                            aria-describedby={getPassengerFieldError(index, 'dateOfBirth') ? `passenger-${index}-dateOfBirth-error` : undefined}
                                             style={{ width: '100%', padding: '8px 12px', borderRadius: '6px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#fff' }}
                                         />
+                                        {getPassengerFieldError(index, 'dateOfBirth') && <div id={`passenger-${index}-dateOfBirth-error`} style={{ color: '#f87171', fontSize: '0.8rem', marginTop: '4px' }}>{getPassengerFieldError(index, 'dateOfBirth')}</div>}
                                     </div>
                                     <div>
                                         <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '4px', color: 'rgba(255,255,255,0.7)' }}>Passport Number</label>
@@ -595,8 +642,12 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                             value={passenger.passportNumber}
                                             onChange={(e) => handlePassengerChange(index, 'passportNumber', e.target.value)}
                                             placeholder="A00000000"
+                                            data-validation-path={`passengers.${index}.passportNumber`}
+                                            aria-invalid={Boolean(getPassengerFieldError(index, 'passportNumber'))}
+                                            aria-describedby={getPassengerFieldError(index, 'passportNumber') ? `passenger-${index}-passportNumber-error` : undefined}
                                             style={{ width: '100%', padding: '8px 12px', borderRadius: '6px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#fff' }}
                                         />
+                                        {getPassengerFieldError(index, 'passportNumber') && <div id={`passenger-${index}-passportNumber-error`} style={{ color: '#f87171', fontSize: '0.8rem', marginTop: '4px' }}>{getPassengerFieldError(index, 'passportNumber')}</div>}
                                     </div>
                                 </div>
 
@@ -708,10 +759,19 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                 <h3 style={{ fontSize: '1rem', color: '#a78bfa', marginBottom: '1rem' }}>Passengers</h3>
                                 <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
                                     {passengers.map((p, idx) => (
-                                        <div
-                                            key={idx}
+                                        <React.Fragment key={idx}>
+                                        <button
+                                            type="button"
                                             onClick={() => setActivePassengerIndex(idx)}
+                                            data-validation-path={`passengers.${idx}.seatNumber`}
+                                            aria-label={`${p.firstName || 'Passenger'} ${p.lastName || `#${idx + 1}`}, Class: ${p.cabinClass}, Seat: ${p.seatNumber || 'Not Chosen'}`}
+                                            aria-pressed={activePassengerIndex === idx}
+                                            data-invalid={Boolean(getPassengerFieldError(idx, 'seatNumber')) || undefined}
+                                            aria-describedby={getPassengerFieldError(idx, 'seatNumber') ? `passenger-${idx}-seatNumber-error` : undefined}
                                             style={{
+                                                width: '100%',
+                                                color: 'inherit',
+                                                textAlign: 'left',
                                                 padding: '12px',
                                                 borderRadius: '8px',
                                                 border: activePassengerIndex === idx ? '2px solid #8b5cf6' : '1px solid rgba(255,255,255,0.08)',
@@ -719,11 +779,17 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                                 cursor: 'pointer',
                                                 transition: 'all 0.2s'
                                             }}>
-                                            <div style={{ fontWeight: 'bold', fontSize: '0.9rem' }}>{p.firstName || 'Passenger'} {p.lastName || `#${idx + 1}`}</div>
-                                            <div style={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.5)', marginTop: '2px' }}>
+                                            <span style={{ display: 'block', fontWeight: 'bold', fontSize: '0.9rem' }}>{p.firstName || 'Passenger'} {p.lastName || `#${idx + 1}`}</span>
+                                            <span style={{ display: 'block', fontSize: '0.75rem', color: 'rgba(255,255,255,0.5)', marginTop: '2px' }}>
                                                 Class: {p.cabinClass} | Seat: <span style={{ color: '#34d399', fontWeight: 'bold' }}>{p.seatNumber || 'Not Chosen'}</span>
+                                            </span>
+                                        </button>
+                                        {getPassengerFieldError(idx, 'seatNumber') && (
+                                            <div id={`passenger-${idx}-seatNumber-error`} style={{ color: '#f87171', fontSize: '0.8rem' }}>
+                                                {getPassengerFieldError(idx, 'seatNumber')}
                                             </div>
-                                        </div>
+                                        )}
+                                        </React.Fragment>
                                     ))}
                                 </div>
                             </div>

--- a/components/ui/ManualOccurrenceBuilder.tsx
+++ b/components/ui/ManualOccurrenceBuilder.tsx
@@ -4,6 +4,7 @@ import React, { useState, useTransition, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { generateFlightOccurrencesAction } from '@/app/actions';
 import { validateSeatingLayout } from '@/lib/seatLayout';
+import { isActionValidationFailure } from '@/lib/actionResult';
 
 interface ScheduleItem {
     id: number;
@@ -106,6 +107,11 @@ export default function ManualOccurrenceBuilder({ schedules }: { schedules: Sche
                         seatPattern: normalizedSeatPattern
                     }
                 );
+
+                if (isActionValidationFailure(result)) {
+                    setError(result.error.message);
+                    return;
+                }
 
                 if (result.success) {
                     setSuccess(

--- a/components/ui/ProfileClient.tsx
+++ b/components/ui/ProfileClient.tsx
@@ -6,6 +6,7 @@ import PointsActivityTable from "@/components/ui/pointsActivityTable";
 import NextStatusChart from "@/components/ui/charts/nextStatusChart";
 import PointsHistoryChart from "@/components/ui/charts/pointsHistoryChart";
 import { cancelBookingAction, deleteReviewAction, toggleFavoriteCityGuideAction, changeBookingSeatsAction, getOccupiedSeatsAction } from '@/app/actions';
+import { isActionValidationFailure } from '@/lib/actionResult';
 import { PointsActivityDisplayData } from '@/lib/types/PointsActivity';
 
 interface Flight {
@@ -126,7 +127,8 @@ export default function ProfileClient({
 
         startTransition(async () => {
             try {
-                await cancelBookingAction(bookingId);
+                const result = await cancelBookingAction(bookingId);
+                if (isActionValidationFailure(result)) throw new Error(result.error.message);
                 router.refresh();
             } catch (error) {
                 alert('Failed to cancel booking. Please try again.');
@@ -139,7 +141,8 @@ export default function ProfileClient({
 
         startTransition(async () => {
             try {
-                await deleteReviewAction(reviewId);
+                const result = await deleteReviewAction(reviewId);
+                if (isActionValidationFailure(result)) throw new Error(result.error.message);
                 router.refresh();
             } catch (error) {
                 alert('Failed to delete review. Please try again.');
@@ -150,7 +153,8 @@ export default function ProfileClient({
     const handleUnfavorite = (cityId: number, cityName: string) => {
         startTransition(async () => {
             try {
-                await toggleFavoriteCityGuideAction(cityId);
+                const result = await toggleFavoriteCityGuideAction(cityId);
+                if (isActionValidationFailure(result)) throw new Error(result.error.message);
                 router.refresh();
             } catch (error) {
                 alert('Failed to update favorite. Please try again.');
@@ -177,7 +181,11 @@ export default function ProfileClient({
                 seatNumber: passengerSeats[pid]
             }));
 
-            await changeBookingSeatsAction(selectedBooking.id, seatChanges);
+            const result = await changeBookingSeatsAction(selectedBooking.id, seatChanges);
+            if (isActionValidationFailure(result)) {
+                setModalError(result.error.message);
+                return;
+            }
             setSelectedBooking(null);
             router.refresh();
         } catch (error: unknown) {
@@ -471,7 +479,7 @@ export default function ProfileClient({
                         </div>
 
                         {modalError && (
-                            <div style={{ backgroundColor: 'rgba(239, 68, 68, 0.15)', color: '#f87171', border: '1px solid rgba(239, 68, 68, 0.3)', padding: '10px', borderRadius: '8px', marginBottom: '1rem', fontSize: '0.9rem' }}>
+                            <div role="alert" style={{ backgroundColor: 'rgba(239, 68, 68, 0.15)', color: '#f87171', border: '1px solid rgba(239, 68, 68, 0.3)', padding: '10px', borderRadius: '8px', marginBottom: '1rem', fontSize: '0.9rem' }}>
                                 ⚠️ {modalError}
                             </div>
                         )}
@@ -482,10 +490,16 @@ export default function ProfileClient({
                                 <h3 style={{ fontSize: '0.95rem', color: '#a78bfa', marginBottom: '0.75rem' }}>Passengers</h3>
                                 <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
                                     {selectedBooking.passengers.map((p, idx) => (
-                                        <div
+                                        <button
+                                            type="button"
                                             key={p.id}
                                             onClick={() => setActivePassengerIdx(idx)}
+                                            aria-pressed={activePassengerIdx === idx}
+                                            aria-label={`${p.firstName} ${p.lastName}, Seat: ${passengerSeats[p.id] || 'None'}, ${p.cabinClass}`}
                                             style={{
+                                                width: '100%',
+                                                color: 'inherit',
+                                                textAlign: 'left',
                                                 padding: '10px',
                                                 borderRadius: '8px',
                                                 border: activePassengerIdx === idx ? '2px solid #8b5cf6' : '1px solid rgba(255,255,255,0.08)',
@@ -497,7 +511,7 @@ export default function ProfileClient({
                                             <div style={{ fontSize: '0.7rem', color: 'rgba(255,255,255,0.5)', marginTop: '2px' }}>
                                                 Seat: <span style={{ color: '#34d399', fontWeight: 'bold' }}>{passengerSeats[p.id] || 'None'}</span> ({p.cabinClass})
                                             </div>
-                                        </div>
+                                        </button>
                                     ))}
                                 </div>
                             </div>

--- a/components/ui/TravelGuideClient.tsx
+++ b/components/ui/TravelGuideClient.tsx
@@ -2,6 +2,7 @@
 import React, { useState, Suspense, useTransition, useSyncExternalStore } from 'react';
 import { ComposableMap, Geographies, Geography, Marker } from "react-simple-maps";
 import { toggleFavoriteCityGuideAction, submitCityGuideReviewAction } from '@/app/actions';
+import { isActionValidationFailure } from '@/lib/actionResult';
 import { useRouter } from 'next/navigation';
 
 const DEFAULT_CITY_NAME = 'Detroit';
@@ -54,7 +55,17 @@ export default function TravelGuideClient({ cities, initialFavorites }: { cities
             });
 
             try {
-                await toggleFavoriteCityGuideAction(cityId);
+                const result = await toggleFavoriteCityGuideAction(cityId);
+                if (isActionValidationFailure(result)) {
+                    setFavorites((prev) => {
+                        const reverted = new Set(prev);
+                        if (reverted.has(cityId)) reverted.delete(cityId);
+                        else reverted.add(cityId);
+                        return reverted;
+                    });
+                    alert(result.error.message);
+                    return;
+                }
             } catch (error) {
                 // Revert state by toggling back
                 setFavorites((prev) => {
@@ -71,7 +82,11 @@ export default function TravelGuideClient({ cities, initialFavorites }: { cities
     const handleReviewSubmit = async (cityId: number) => {
         if (!reviewContent.trim()) return;
         try {
-            await submitCityGuideReviewAction(cityId, reviewRating, reviewContent);
+            const result = await submitCityGuideReviewAction(cityId, reviewRating, reviewContent);
+            if (isActionValidationFailure(result)) {
+                alert(result.error.message);
+                return;
+            }
             setReviewContent('');
             router.refresh(); // Refresh page to show the new review
         } catch (error) {

--- a/components/ui/flightBookingForm.tsx
+++ b/components/ui/flightBookingForm.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
 import { searchFlightsAction } from '@/app/actions'
 import { Flight } from '@prisma/client'
+import { isActionValidationFailure } from '@/lib/actionResult'
 
 interface FlightBookingFormProps {
     routes?: { from: string; to: string }[];
@@ -48,9 +49,13 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({ routes = [] }) =>
 
         try {
             const results = await searchFlightsAction(fromLocation, toLocation, departureDate);
+            if (isActionValidationFailure(results)) {
+                setBookingState({ status: 'error', message: results.error.message });
+                return;
+            }
             setSearchResults(results);
         } catch (error) {
-            console.error(error);
+            setBookingState({ status: 'error', message: 'Unable to search for flights right now.' });
         } finally {
             setIsSearching(false);
         }

--- a/components/ui/flightScheduleForm.tsx
+++ b/components/ui/flightScheduleForm.tsx
@@ -4,6 +4,7 @@ import React, { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { saveFlightScheduleAction } from '@/app/actions';
 import { validateSeatingLayout } from '@/lib/seatLayout';
+import { isActionValidationFailure } from '@/lib/actionResult';
 
 interface FlightSchedule {
     id?: number;
@@ -109,7 +110,7 @@ export default function FlightScheduleForm({ initialSchedule }: { initialSchedul
 
         startTransition(async () => {
             try {
-                await saveFlightScheduleAction({
+                const result = await saveFlightScheduleAction({
                     id: initialSchedule?.id,
                     flightNumber,
                     airline,
@@ -125,6 +126,10 @@ export default function FlightScheduleForm({ initialSchedule }: { initialSchedul
                     economyRows: eRows,
                     seatPattern: normalizedSeatPattern
                 });
+                if (isActionValidationFailure(result)) {
+                    setError(result.error.message);
+                    return;
+                }
 
                 setSuccess(initialSchedule ? 'Schedule updated successfully!' : 'New schedule created successfully!');
                 if (!initialSchedule) {

--- a/components/ui/travelGuideForm.tsx
+++ b/components/ui/travelGuideForm.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { saveCityGuideAction } from '@/app/actions';
 import CityGuide from '../../lib/types/CityGuide';
+import { isActionValidationFailure } from '@/lib/actionResult';
 
 const TravelGuideForm: React.FC = () => {
   const [city, setCity] = useState('');
@@ -11,7 +12,7 @@ const TravelGuideForm: React.FC = () => {
   const [latitude, setLatitude] = useState<number | null>(null);
   const [longitude, setLongitude] = useState<number | null>(null);
   const [error, setError] = useState<string>('');
-  const [saveresult, setSaveResult] = useState<string>('');
+  const [saveFeedback, setSaveFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [showAddButtons, setShowAddButtons] = useState<boolean[]>([true]);
   const [coverImage, setCoverImage] = useState<string | null>(null);
 
@@ -51,18 +52,15 @@ const TravelGuideForm: React.FC = () => {
         setLatitude(parseFloat(data[0].lat));
         setLongitude(parseFloat(data[0].lon));
         setError('');
-        console.log({ latitude, longitude });
       } else {
         setLatitude(null);
         setLongitude(null);
         setError('Location not found.');
-        console.log('Location not found.');
       }
     } catch {
       setLatitude(null);
       setLongitude(null);
       setError('Failed to fetch coordinates.');
-      console.log('Failed to fetch coordinates.');
     }
   };
 
@@ -78,7 +76,7 @@ const TravelGuideForm: React.FC = () => {
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    console.log({ city, country, description, highlights, latitude, longitude, coverImage });
+    setSaveFeedback(null);
     const cityGuide: CityGuide = {
       id: 1,
       city: city,
@@ -89,8 +87,12 @@ const TravelGuideForm: React.FC = () => {
       coverImage: coverImage || undefined
     };
     saveCityGuideAction(cityGuide)
-      .then(() => setSaveResult('City guide saved successfully'))
-      .catch(() => setSaveResult('Failed to save city guide'));
+      .then((result) => setSaveFeedback(
+        isActionValidationFailure(result)
+          ? { type: 'error', message: result.error.message }
+          : { type: 'success', message: 'City guide saved successfully' }
+      ))
+      .catch(() => setSaveFeedback({ type: 'error', message: 'Failed to save city guide' }));
   };
 
 
@@ -176,7 +178,14 @@ const TravelGuideForm: React.FC = () => {
         <button type="submit">
           Submit
         </button>
-        {saveresult && <div className="text-green-500 mb-4">{saveresult}</div>}
+        {saveFeedback && (
+          <div
+            role={saveFeedback.type === 'error' ? 'alert' : 'status'}
+            className={`${saveFeedback.type === 'error' ? 'text-red-500' : 'text-green-500'} mb-4`}
+          >
+            {saveFeedback.message}
+          </div>
+        )}
       </form>
     </div>
   );

--- a/lib/FlightBookingService.ts
+++ b/lib/FlightBookingService.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { assertSeatAvailableForCabin } from '@/lib/seatLayout';
 import { lockFlightForUpdate } from '@/lib/flightLock';
+import { flightBookingServiceSchema, parseInput } from '@/lib/validation';
 
 export interface PassengerInput {
   firstName: string;
@@ -17,91 +18,75 @@ export default class FlightBookingService {
         flightId?: number; 
         userId?: string; 
         totalPrice?: string; 
-        passengers?: PassengerInput[]; 
+        passengers: PassengerInput[];
         paymentIntentId?: string; 
     }) {
-        const { flightId, userId, totalPrice, passengers, paymentIntentId } = bookingData;
-        if (!flightId || !userId) {
-            throw new Error("flightId and userId are required to book a flight.");
-        }
+        const { flightId, userId, totalPrice, passengers, paymentIntentId } = parseInput(
+            flightBookingServiceSchema,
+            bookingData
+        );
 
         // Run booking inside a database transaction to ensure atomic execution
         const savedBooking = await prisma.$transaction(async (tx) => {
-            // If passengers list is provided, validate seat numbers
-            if (passengers && passengers.length > 0) {
-                await lockFlightForUpdate(tx, flightId);
-                const flight = await tx.flight.findUnique({ where: { id: flightId } });
-                if (!flight) throw new Error("Flight not found");
+            await lockFlightForUpdate(tx, flightId);
+            const flight = await tx.flight.findUnique({ where: { id: flightId } });
+            if (!flight) throw new Error("Flight not found");
 
-                // Check if any seat is already booked on this flight
-                const requestedSeats = passengers.map(p => p.seatNumber);
-                if (new Set(requestedSeats).size !== requestedSeats.length) {
-                    throw new Error("Duplicate seats selected in request.");
-                }
-
-                for (const passenger of passengers) {
-                    assertSeatAvailableForCabin(
-                        passenger.seatNumber,
-                        passenger.cabinClass,
-                        flight
-                    );
-                }
-                
-                const existingBookings = await tx.booking.findMany({
-                    where: { flightId, status: { not: "CANCELLED" } },
-                    include: { passengers: true }
-                });
-
-                const occupiedSeats = new Set(
-                    existingBookings
-                        .flatMap(b => b.passengers)
-                        .map(p => p.seatNumber)
-                );
-
-                for (const seat of requestedSeats) {
-                    if (occupiedSeats.has(seat)) {
-                        throw new Error(`Seat ${seat} is already occupied on this flight.`);
-                    }
-                }
-
-                // Create booking with nested passengers
-                return await tx.booking.create({
-                    data: {
-                        flightId,
-                        userId,
-                        totalPrice: totalPrice || "$0",
-                        paymentIntentId: paymentIntentId || `mock_tx_${Date.now()}`,
-                        passengers: {
-                            create: passengers.map(p => ({
-                                firstName: p.firstName,
-                                lastName: p.lastName,
-                                dateOfBirth: new Date(p.dateOfBirth),
-                                passportNumber: p.passportNumber,
-                                gender: p.gender,
-                                seatNumber: p.seatNumber,
-                                cabinClass: p.cabinClass,
-                                flightId // Pass flightId directly
-                            }))
-                        }
-                    },
-                    include: {
-                        passengers: true
-                    }
-                });
-            } else {
-                // Fallback to simple booking for backward compatibility/legacy tests
-                const flight = await tx.flight.findUnique({
-                    where: { id: flightId }
-                });
-                return await tx.booking.create({
-                    data: {
-                        flightId,
-                        userId,
-                        totalPrice: flight?.price || "$0",
-                        paymentIntentId: `mock_tx_${Date.now()}`
-                    }
-                });
+            // Check if any seat is already booked on this flight
+            const requestedSeats = passengers.map(p => p.seatNumber);
+            if (new Set(requestedSeats).size !== requestedSeats.length) {
+                throw new Error("Duplicate seats selected in request.");
             }
+
+            for (const passenger of passengers) {
+                assertSeatAvailableForCabin(
+                    passenger.seatNumber,
+                    passenger.cabinClass,
+                    flight
+                );
+            }
+
+            const existingBookings = await tx.booking.findMany({
+                where: { flightId, status: { not: "CANCELLED" } },
+                include: { passengers: true }
+            });
+
+            const occupiedSeats = new Set(
+                existingBookings
+                    .flatMap(b => b.passengers)
+                    .map(p => p.seatNumber)
+            );
+
+            for (const seat of requestedSeats) {
+                if (occupiedSeats.has(seat)) {
+                    throw new Error(`Seat ${seat} is already occupied on this flight.`);
+                }
+            }
+
+            // Create booking with nested passengers
+            return await tx.booking.create({
+                data: {
+                    flightId,
+                    userId,
+                    totalPrice: totalPrice || "$0",
+                    paymentIntentId: paymentIntentId || `mock_tx_${Date.now()}`,
+                    passengers: {
+                        create: passengers.map(p => ({
+                            firstName: p.firstName,
+                            lastName: p.lastName,
+                            dateOfBirth: new Date(p.dateOfBirth),
+                            passportNumber: p.passportNumber,
+                            gender: p.gender,
+                            seatNumber: p.seatNumber,
+                            cabinClass: p.cabinClass,
+                            flightId
+                        }))
+                    }
+                },
+                include: {
+                    passengers: true
+                }
+            });
         });
 
         return savedBooking;

--- a/lib/TravelGuideService.ts
+++ b/lib/TravelGuideService.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import CityGuide from "./types/CityGuide";
+import { cityGuideSchema, parseInput } from "./validation";
 
 class TravelGuideService {
 
@@ -14,6 +15,7 @@ class TravelGuideService {
   }
 
   async saveCityGuide(cityGuide: CityGuide): Promise<CityGuide> {
+    cityGuide = parseInput(cityGuideSchema, cityGuide) as CityGuide;
     const saved = await prisma.cityGuide.create({
       data: {
         city: cityGuide.city,

--- a/lib/actionResult.ts
+++ b/lib/actionResult.ts
@@ -1,0 +1,28 @@
+export interface ActionValidationFailure {
+    ok: false;
+    error: {
+        code: 'VALIDATION_ERROR';
+        message: string;
+        fields: Record<string, string[]>;
+    };
+}
+
+export function isActionValidationFailure(value: unknown): value is ActionValidationFailure {
+    if (!value || typeof value !== 'object') return false;
+    const candidate = value as Partial<ActionValidationFailure>;
+    return candidate.ok === false && candidate.error?.code === 'VALIDATION_ERROR';
+}
+
+export function actionValidationFailure(
+    message: string,
+    field = '_root'
+): ActionValidationFailure {
+    return {
+        ok: false,
+        error: {
+            code: 'VALIDATION_ERROR',
+            message,
+            fields: { [field]: [message] }
+        }
+    };
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,321 @@
+import { z, ZodError, ZodType } from 'zod';
+import { validateSeatingLayout } from '@/lib/seatLayout';
+import { ActionValidationFailure } from '@/lib/actionResult';
+
+export const MAX_MUTATION_BYTES = 1_000_000;
+export const MAX_REGISTRATION_BYTES = 16_384;
+export const MAX_PASSENGERS_PER_BOOKING = 9;
+
+const requiredText = (label: string, max: number) => z.string()
+    .trim()
+    .min(1, `${label} is required.`)
+    .max(max, `${label} is too long.`);
+
+const positiveId = (label: string) => z.number({ error: `${label} must be a number.` })
+    .int(`${label} must be an integer.`)
+    .positive(`${label} must be positive.`);
+
+const dateOnlySchema = z.union([z.string(), z.date()]).transform((value, context) => {
+    if (value instanceof Date && Number.isNaN(value.getTime())) {
+        context.addIssue({ code: 'custom', message: 'Date is invalid.' });
+        return z.NEVER;
+    }
+    const rawValue = value instanceof Date ? value.toISOString() : value.trim();
+    const isDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(rawValue);
+    const isIsoDateTime = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/.test(rawValue);
+    if (!isDateOnly && !isIsoDateTime) {
+        context.addIssue({ code: 'custom', message: 'Date must use YYYY-MM-DD or ISO datetime format.' });
+        return z.NEVER;
+    }
+    if (isIsoDateTime && Number.isNaN(new Date(rawValue).getTime())) {
+        context.addIssue({ code: 'custom', message: 'Date is invalid.' });
+        return z.NEVER;
+    }
+    const stringValue = isIsoDateTime ? rawValue.slice(0, 10) : rawValue;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(stringValue)) {
+        context.addIssue({ code: 'custom', message: 'Date must use YYYY-MM-DD format.' });
+        return z.NEVER;
+    }
+    const date = new Date(`${stringValue}T00:00:00.000Z`);
+    if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== stringValue) {
+        context.addIssue({ code: 'custom', message: 'Date is invalid.' });
+        return z.NEVER;
+    }
+    const today = new Date();
+    const todayString = today.toISOString().slice(0, 10);
+    if (stringValue > todayString || stringValue < '1900-01-01') {
+        context.addIssue({
+            code: 'custom',
+            message: 'Date must be between 1900-01-01 and today.'
+        });
+        return z.NEVER;
+    }
+    return stringValue;
+});
+
+const isoDateSchema = z.string().trim().regex(/^\d{4}-\d{2}-\d{2}$/, 'Dates must use YYYY-MM-DD format.')
+    .refine(value => {
+        const date = new Date(`${value}T00:00:00.000Z`);
+        return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+    }, 'Date is invalid.');
+
+export const registrationSchema = z.object({
+    name: requiredText('Name', 100),
+    email: z.string()
+        .trim()
+        .toLowerCase()
+        .max(254, 'Email address is too long.')
+        .email('Enter a valid email address.'),
+    password: z.string()
+        .min(8, 'Password must be at least 8 characters.')
+        .max(128, 'Password is too long.')
+}).strict();
+
+export const favoriteSchema = z.object({
+    cityGuideId: positiveId('City guide ID')
+}).strict();
+
+export const reviewSchema = z.object({
+    cityGuideId: positiveId('City guide ID'),
+    rating: z.number().int().min(1).max(5),
+    content: requiredText('Review', 2_000)
+}).strict();
+
+export const searchFlightsSchema = z.object({
+    from: requiredText('Origin', 120),
+    to: requiredText('Destination', 120),
+    departureDate: isoDateSchema.optional()
+}).strict();
+
+const coverImageSchema = z.string()
+    .trim()
+    .max(750_000, 'Cover image is too large.')
+    .refine(
+        value => value.startsWith('data:image/') || value.startsWith('/') || /^https?:\/\//.test(value),
+        'Cover image must be an image URL or data URL.'
+    );
+
+export const cityGuideSchema = z.object({
+    id: positiveId('City guide ID').optional(),
+    city: requiredText('City', 100),
+    country: requiredText('Country', 100),
+    latlong: z.tuple([
+        z.number().finite().min(-90).max(90),
+        z.number().finite().min(-180).max(180)
+    ]),
+    description: requiredText('Description', 5_000),
+    highlights: z.array(requiredText('Highlight', 200)).min(1).max(20),
+    coverImage: coverImageSchema.nullish()
+}).strict();
+
+const timeSchema = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'Time must use HH:MM format.');
+const rowCountSchema = z.number()
+    .int('Row configurations must be non-negative integers.')
+    .nonnegative('Row configurations must be non-negative integers.');
+
+export const scheduleSchema = z.object({
+    id: positiveId('Schedule ID').optional(),
+    flightNumber: requiredText('Flight number', 10)
+        .transform(value => value.toUpperCase().replace(/\s+/g, ''))
+        .pipe(z.string().regex(/^[A-Z0-9]{2,10}$/, 'Flight number contains invalid characters.')),
+    airline: requiredText('Airline', 120),
+    from: requiredText('Origin', 120),
+    to: requiredText('Destination', 120),
+    departureTime: timeSchema,
+    returnTime: z.union([timeSchema, z.null()]),
+    daysOfWeek: z.array(z.number().int().min(0).max(6))
+        .min(1)
+        .max(7)
+        .refine(days => new Set(days).size === days.length, 'Days of week must be unique.')
+        .transform(days => [...days].sort((left, right) => left - right)),
+    price: requiredText('Price', 32).regex(/^\$?\d+(?:\.\d{1,2})?$/, 'Price format is invalid.'),
+    firstClassRows: rowCountSchema.default(3),
+    businessRows: rowCountSchema.default(3),
+    premiumEconomyRows: rowCountSchema.default(4),
+    economyRows: rowCountSchema.default(20),
+    seatPattern: z.string().default('ABC-DEF')
+}).strict().transform((schedule, context) => {
+    try {
+        return {
+            ...schedule,
+            seatPattern: validateSeatingLayout(
+                schedule.firstClassRows,
+                schedule.businessRows,
+                schedule.premiumEconomyRows,
+                schedule.economyRows,
+                schedule.seatPattern
+            )
+        };
+    } catch (error) {
+        context.addIssue({
+            code: 'custom',
+            path: ['seatPattern'],
+            message: error instanceof Error ? error.message : 'Seating layout is invalid.'
+        });
+        return z.NEVER;
+    }
+});
+
+export const passengerSchema = z.object({
+    firstName: requiredText('First name', 100),
+    lastName: requiredText('Last name', 100),
+    dateOfBirth: dateOnlySchema,
+    passportNumber: requiredText('Passport number', 32)
+        .transform(value => value.toUpperCase())
+        .pipe(z.string().regex(/^[A-Z0-9-]+$/, 'Passport number contains invalid characters.')),
+    gender: z.enum(['Male', 'Female', 'Other']),
+    seatNumber: requiredText('Seat number', 6)
+        .transform(value => value.toUpperCase())
+        .pipe(z.string().regex(/^[1-9]\d{0,2}[A-Z]$/, 'Seat number is invalid.')),
+    cabinClass: z.enum(['ECONOMY', 'PREMIUM_ECONOMY', 'BUSINESS', 'FIRST'])
+}).strict();
+
+export const bookingRequestSchema = z.object({
+    flightId: positiveId('Flight ID'),
+    totalPrice: z.string().trim().max(32).optional(),
+    passengers: z.array(passengerSchema, { error: 'At least one passenger is required.' })
+        .min(1, 'At least one passenger is required.')
+        .max(MAX_PASSENGERS_PER_BOOKING),
+    paymentIntentId: z.string().trim().min(1).max(255).optional()
+}).strict();
+
+export const flightBookingServiceSchema = bookingRequestSchema.extend({
+    userId: requiredText('User ID', 128)
+});
+
+const seatChangeSchema = z.object({
+    passengerId: requiredText('Passenger ID', 128),
+    seatNumber: requiredText('Seat number', 6)
+        .transform(value => value.toUpperCase())
+        .pipe(z.string().regex(/^[1-9]\d{0,2}[A-Z]$/, 'Seat number is invalid.'))
+}).strict();
+
+export const seatChangesSchema = z.object({
+    bookingId: positiveId('Booking ID'),
+    seatChanges: z.array(seatChangeSchema).min(1).max(MAX_PASSENGERS_PER_BOOKING)
+}).strict().superRefine(({ seatChanges }, context) => {
+    const passengerIds = seatChanges.map(change => change.passengerId);
+    const seats = seatChanges.map(change => change.seatNumber);
+    if (new Set(passengerIds).size !== passengerIds.length) {
+        context.addIssue({ code: 'custom', path: ['seatChanges'], message: 'Passengers must be unique.' });
+    }
+    if (new Set(seats).size !== seats.length) {
+        context.addIssue({ code: 'custom', path: ['seatChanges'], message: 'Seats must be unique.' });
+    }
+});
+
+export const numericIdSchema = positiveId('ID');
+export const stringIdSchema = requiredText('ID', 128);
+export const flightStatusSchema = z.enum(['ON_TIME', 'DELAYED', 'CANCELLED']);
+
+export const occurrenceRequestSchema = z.object({
+    scheduleId: positiveId('Schedule ID'),
+    startDate: isoDateSchema,
+    endDate: isoDateSchema,
+    seatingConfig: z.object({
+        firstClassRows: rowCountSchema.nullish(),
+        businessRows: rowCountSchema.nullish(),
+        premiumEconomyRows: rowCountSchema.nullish(),
+        economyRows: rowCountSchema.nullish(),
+        seatPattern: z.string().max(64).nullish()
+    }).strict().optional()
+}).strict().refine(input => input.endDate >= input.startDate, {
+    path: ['endDate'],
+    message: 'End date must be on or after start date.'
+}).refine(input => {
+    const start = new Date(`${input.startDate}T00:00:00.000Z`);
+    const end = new Date(`${input.endDate}T00:00:00.000Z`);
+    return (end.getTime() - start.getTime()) / 86_400_000 <= 366;
+}, {
+    path: ['endDate'],
+    message: 'Date range cannot exceed 366 days.'
+});
+
+export class InputValidationError extends Error {
+    readonly code = 'VALIDATION_ERROR';
+    readonly fields: Record<string, string[]>;
+
+    constructor(fields: Record<string, string[]>, message = 'Please correct the highlighted fields.') {
+        super(message);
+        this.name = 'InputValidationError';
+        this.fields = fields;
+    }
+}
+
+function serializedBytes(input: unknown): number {
+    try {
+        return Buffer.byteLength(JSON.stringify(input) ?? '', 'utf8');
+    } catch {
+        throw new InputValidationError({ _root: ['Request could not be read.'] });
+    }
+}
+
+export function parseInput<T>(schema: ZodType<T>, input: unknown, maxBytes = MAX_MUTATION_BYTES): T {
+    if (serializedBytes(input) > maxBytes) {
+        throw new InputValidationError({ _root: ['Request is too large.'] }, 'Request is too large.');
+    }
+    try {
+        return schema.parse(input);
+    } catch (error) {
+        if (!(error instanceof ZodError)) throw error;
+        const fields: Record<string, string[]> = {};
+        for (const issue of error.issues) {
+            const field = issue.path.join('.') || '_root';
+            fields[field] = [...(fields[field] ?? []), issue.message];
+        }
+        throw new InputValidationError(fields, error.issues[0]?.message);
+    }
+}
+
+export function validationErrorPayload(error: InputValidationError) {
+    return {
+        error: {
+            code: error.code,
+            message: error.message,
+            fields: error.fields
+        }
+    };
+}
+
+export function parseActionInput<T>(
+    schema: ZodType<T>,
+    input: unknown,
+    maxBytes = MAX_MUTATION_BYTES
+): { ok: true; data: T } | ActionValidationFailure {
+    try {
+        return { ok: true, data: parseInput(schema, input, maxBytes) };
+    } catch (error) {
+        if (!(error instanceof InputValidationError)) throw error;
+        return {
+            ok: false,
+            error: {
+                code: 'VALIDATION_ERROR',
+                message: error.message,
+                fields: error.fields
+            }
+        };
+    }
+}
+
+export async function parseJsonRequest<T>(
+    request: Request,
+    schema: ZodType<T>,
+    maxBytes = MAX_REGISTRATION_BYTES
+): Promise<T> {
+    const declaredLength = Number(request.headers.get('content-length'));
+    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+        throw new InputValidationError({ _root: ['Request is too large.'] }, 'Request is too large.');
+    }
+
+    const body = await request.text();
+    if (Buffer.byteLength(body, 'utf8') > maxBytes) {
+        throw new InputValidationError({ _root: ['Request is too large.'] }, 'Request is too large.');
+    }
+    let input: unknown;
+    try {
+        input = JSON.parse(body);
+    } catch {
+        throw new InputValidationError({ _root: ['Request body must be valid JSON.'] });
+    }
+    return parseInput(schema, input, maxBytes);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "^18",
         "react-simple-maps": "^3.0.0",
         "recharts": "^2.12.7",
-        "tailwind-merge": "^2.5.2"
+        "tailwind-merge": "^2.5.2",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@babel/core": "^7.29.6",
@@ -12571,7 +12572,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-dom": "^18",
     "react-simple-maps": "^3.0.0",
     "recharts": "^2.12.7",
-    "tailwind-merge": "^2.5.2"
+    "tailwind-merge": "^2.5.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",


### PR DESCRIPTION
## Summary
Add authoritative, shared server validation for public and administrative mutations so bypassing the UI cannot submit malformed or oversized data.

## Changes
- add strict Zod schemas, normalization, structured safe errors, and mutation/request size limits
- validate registration, flight search, bookings/passengers, favorites, reviews, city guides, schedules, occurrences, seat changes, IDs, and statuses
- require passengers for bookings and remove the zero-passenger legacy path
- surface structured validation feedback in affected forms and accessible wizard fields
- mark roadmap item P0.3 complete

## Testing
- [x] Unit tests added/updated
- [x] Manual testing steps: exercised registration, search, booking, profile seat changes, travel guides, and admin error paths through Jest and Playwright
- [x] 28 Jest suites / 218 tests
- [x] TypeScript and ESLint
- [x] Production build and production dependency audit
- [x] Prisma migrations/seed and 8 Chromium Playwright journeys
- [x] Docker image build and container secret/layer scan

## Screenshots (if applicable)
Not applicable; validation feedback uses existing UI treatments.

## Related Issues
Roadmap P0.3