### PR TITLE
feat(booking): make pricing and inventory authoritative

### DIFF
--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -100,11 +100,11 @@ Acceptance criteria:
 
 ### P0.4 Make pricing and booking authoritative
 
-- [ ] Stop accepting the final price from the browser.
-- [ ] Stop accepting or generating trusted payment identifiers in client code.
-- [ ] Load the flight, fare, cabin, and price on the server at booking time.
-- [ ] Verify selected seats and passenger count against available inventory.
-- [ ] Add an idempotency mechanism that prevents duplicate bookings.
+- [x] Stop accepting the final price from the browser.
+- [x] Stop accepting or generating trusted payment identifiers in client code.
+- [x] Load the flight, fare, cabin, and price on the server at booking time.
+- [x] Verify selected seats and passenger count against available inventory.
+- [x] Add an idempotency mechanism that prevents duplicate bookings.
 
 Acceptance criteria:
 
@@ -501,6 +501,7 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-12 | P0.2 | Complete | #35 | Upgraded Next.js, Auth, D3, Node, and ESLint; cleared the production audit; and added CI enforcement. |
 | 2026-07-12 | P1.4 | In progress | #32 | Added a concurrency-safe manual occurrence generator with custom seating; scheduled background generation and horizon monitoring remain. |
 | 2026-07-12 | P0.3 | Complete | #37 | Added shared Zod schemas, normalized mutation inputs, structured safe errors, and request/mutation limits. |
+| 2026-07-12 | P0.4 | Complete | Pending | Made server fares and inventory authoritative, removed fake payment identifiers, and added idempotent, concurrency-tested booking persistence. |
 
 ## Recommended first delivery sequence
 

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -501,7 +501,7 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-12 | P0.2 | Complete | #35 | Upgraded Next.js, Auth, D3, Node, and ESLint; cleared the production audit; and added CI enforcement. |
 | 2026-07-12 | P1.4 | In progress | #32 | Added a concurrency-safe manual occurrence generator with custom seating; scheduled background generation and horizon monitoring remain. |
 | 2026-07-12 | P0.3 | Complete | #37 | Added shared Zod schemas, normalized mutation inputs, structured safe errors, and request/mutation limits. |
-| 2026-07-12 | P0.4 | Complete | Pending | Made server fares and inventory authoritative, removed fake payment identifiers, and added idempotent, concurrency-tested booking persistence. |
+| 2026-07-12 | P0.4 | Complete | #38 | Made server fares and inventory authoritative, removed fake payment identifiers, and added idempotent, concurrency-tested booking persistence. |
 
 ## Recommended first delivery sequence
 

--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -259,7 +259,13 @@ describe('bookFlightAction', () => {
 
     it('calls FlightBookingService with flightId and userId from session and creates a notification', async () => {
         mockedGetServerSession.mockResolvedValue({ user: { id: 'user-123' } });
-        mockBookFlight.mockResolvedValue({ id: 1, flightId: 42, userId: 'user-123' });
+        mockBookFlight.mockResolvedValue({
+            id: 1,
+            flightId: 42,
+            userId: 'user-123',
+            totalPrice: '$200',
+            wasCreated: true
+        });
         mockedFlightFindUnique.mockResolvedValue({
             id: 42,
             airline: 'Gemini Airways',
@@ -274,15 +280,25 @@ describe('bookFlightAction', () => {
             passportNumber: 'AB123456', gender: 'Female', seatNumber: '11A',
             cabinClass: 'ECONOMY'
         }];
-        const result = await bookFlightAction({ flightId: 42, totalPrice: '$200', passengers });
+        const result = await bookFlightAction({
+            flightId: 42,
+            passengers,
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
+        });
 
         expect(mockBookFlight).toHaveBeenCalledWith(expect.objectContaining({
             flightId: 42,
             userId: 'user-123',
-            totalPrice: '$200',
-            passengers
+            passengers,
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         }));
-        expect(result).toEqual({ id: 1, flightId: 42, userId: 'user-123' });
+        expect(result).toEqual({
+            id: 1,
+            flightId: 42,
+            userId: 'user-123',
+            totalPrice: '$200',
+            wasCreated: true
+        });
 
         expect(mockedNotificationCreate).toHaveBeenCalledWith({
             data: {
@@ -304,7 +320,8 @@ describe('bookFlightAction', () => {
 
         await expect(bookFlightAction({
             flightId: 42,
-            passengers: Array.from({ length: 10 }, () => passenger)
+            passengers: Array.from({ length: 10 }, () => passenger),
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         })).resolves.toMatchObject({ ok: false, error: { code: 'VALIDATION_ERROR' } });
         expect(mockBookFlight).not.toHaveBeenCalled();
     });
@@ -317,6 +334,51 @@ describe('bookFlightAction', () => {
             error: { code: 'VALIDATION_ERROR', fields: { passengers: expect.any(Array) } }
         });
         expect(mockBookFlight).not.toHaveBeenCalled();
+    });
+
+    it('rejects client prices and payment identifiers before calling the booking service', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { id: 'user-123' } });
+        const passenger = {
+            firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: '1990-01-01',
+            passportNumber: 'AB123456', gender: 'Female', seatNumber: '11A',
+            cabinClass: 'ECONOMY'
+        };
+
+        await expect(bookFlightAction({
+            flightId: 42,
+            passengers: [passenger],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735',
+            totalPrice: '$0.01',
+            paymentIntentId: 'forged-payment'
+        } as any)).resolves.toMatchObject({
+            ok: false,
+            error: { code: 'VALIDATION_ERROR' }
+        });
+        expect(mockBookFlight).not.toHaveBeenCalled();
+    });
+
+    it('does not duplicate booking notifications for an idempotent retry', async () => {
+        mockedGetServerSession.mockResolvedValue({ user: { id: 'user-123' } });
+        mockBookFlight.mockResolvedValue({
+            id: 1,
+            flightId: 42,
+            userId: 'user-123',
+            totalPrice: '$200',
+            wasCreated: false
+        });
+        mockedFlightFindUnique.mockResolvedValue({ id: 42, flightNumber: 'GA101' });
+
+        await bookFlightAction({
+            flightId: 42,
+            passengers: [{
+                firstName: 'Ada', lastName: 'Lovelace', dateOfBirth: '1990-01-01',
+                passportNumber: 'AB123456', gender: 'Female', seatNumber: '11A',
+                cabinClass: 'ECONOMY'
+            }],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
+        });
+
+        expect(mockedNotificationCreate).not.toHaveBeenCalled();
     });
 });
 
@@ -428,7 +490,7 @@ describe('cancelBookingAction', () => {
         mockedBookingFindUnique.mockResolvedValue({
             id: 1,
             userId: 'user-123',
-            totalPrice: '$200',
+            totalPrice: '$69.97',
             flightId: 10,
             flight: { flightNumber: 'GA101', airline: 'Gemini Airways', price: '$200' }
         });
@@ -451,7 +513,7 @@ describe('cancelBookingAction', () => {
             data: {
                 userId: 'user-123',
                 title: 'Booking Cancelled: Gemini Airways GA101',
-                message: 'Booking for flight GA101 has been cancelled. Deducted -200 status points.',
+                message: 'Booking for flight GA101 has been cancelled. Deducted -69 status points.',
                 type: 'POINTS'
             }
         });

--- a/__tests__/components/BookingCheckoutWizard.test.tsx
+++ b/__tests__/components/BookingCheckoutWizard.test.tsx
@@ -34,7 +34,7 @@ describe('BookingCheckoutWizard', () => {
         expect(screen.getByText('Passenger #1')).toBeInTheDocument();
 
         // Total price should initially be $100 (Economy)
-        expect(screen.getByText('Total: $100')).toBeInTheDocument();
+        expect(screen.getByText('Estimated total: $100')).toBeInTheDocument();
 
         // Fill passenger details
         fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Alice' } });
@@ -48,14 +48,14 @@ describe('BookingCheckoutWizard', () => {
         fireEvent.change(classSelect, { target: { value: 'BUSINESS' } });
 
         // Total price should double to $200
-        expect(screen.getByText('Total: $200')).toBeInTheDocument();
+        expect(screen.getByText('Estimated total: $200')).toBeInTheDocument();
 
         // Add a second passenger
         fireEvent.click(screen.getByText('+ Add Traveler'));
         expect(screen.getByText('Passenger #2')).toBeInTheDocument();
 
         // Total price should be $200 (Passenger 1: Business) + $100 (Passenger 2: Economy) = $300
-        expect(screen.getByText('Total: $300')).toBeInTheDocument();
+        expect(screen.getByText('Estimated total: $300')).toBeInTheDocument();
 
         // Remove Passenger #2
         const removeButtons = screen.getAllByText('✕ Remove');
@@ -63,7 +63,7 @@ describe('BookingCheckoutWizard', () => {
 
         // Verify Passenger #2 is removed and price updates back to $200
         expect(screen.queryByText('Passenger #2')).not.toBeInTheDocument();
-        expect(screen.getByText('Total: $200')).toBeInTheDocument();
+        expect(screen.getByText('Estimated total: $200')).toBeInTheDocument();
     });
 
     it('shows validation errors in Step 1 if fields are missing', async () => {
@@ -133,14 +133,20 @@ describe('BookingCheckoutWizard', () => {
         expect(screen.getByText(/Seat:/).textContent).toContain('4A');
 
         // Proceed to Step 3
-        fireEvent.click(screen.getByText('Billing & Summary →'));
-        expect(screen.getByText('Review & Purchase')).toBeInTheDocument();
+        fireEvent.click(screen.getByText('Review Booking →'));
+        expect(screen.getByText('Review Booking')).toBeInTheDocument();
     });
 
-    it('validates card payment details and completes booking successfully (Step 3 & 4)', async () => {
+    it('confirms a server-priced booking without collecting payment card data', async () => {
         mockBookFlightAction.mockResolvedValue({
             id: 12345,
-            paymentIntentId: 'ch_mock123'
+            totalPrice: '$100',
+            passengers: [{
+                firstName: 'Robert',
+                lastName: 'Jones',
+                seatNumber: '11C',
+                cabinClass: 'ECONOMY'
+            }]
         });
 
         const { container } = render(<BookingCheckoutWizard flight={sampleFlight} occupiedSeats={[]} />);
@@ -159,25 +165,18 @@ describe('BookingCheckoutWizard', () => {
         fireEvent.click(seat11C);
         
         // Proceed to Billing
-        fireEvent.click(screen.getByText('Billing & Summary →'));
+        fireEvent.click(screen.getByText('Review Booking →'));
 
         // Verify summary details are correct
         expect(screen.getByText('Bob Jones')).toBeInTheDocument();
         expect(screen.getByText('Class: ECONOMY | Seat: 11C')).toBeInTheDocument();
-        expect(screen.getByText('Total Price')).toBeInTheDocument();
+        expect(screen.getByText('Estimated Total')).toBeInTheDocument();
 
-        // Try to pay with invalid card number
-        fireEvent.click(screen.getByRole('button', { name: /Pay \$100 & Book/i }));
-        expect(screen.getByText(/Card number must be 16 digits/i)).toBeInTheDocument();
-
-        // Fill card info properly
-        fireEvent.change(screen.getByPlaceholderText('4111 2222 3333 4444'), { target: { value: '4111 2222 3333 4444' } });
-        fireEvent.change(screen.getByPlaceholderText('JOHN DOE'), { target: { value: 'BOB JONES' } });
-        fireEvent.change(screen.getByPlaceholderText('MM/YY'), { target: { value: '12/29' } });
-        fireEvent.change(screen.getByPlaceholderText('123'), { target: { value: '123' } });
+        expect(screen.queryByPlaceholderText('4111 2222 3333 4444')).not.toBeInTheDocument();
+        expect(screen.getByText(/Payment is not collected in this demo/i)).toBeInTheDocument();
 
         // Submit Booking
-        fireEvent.click(screen.getByRole('button', { name: /Pay \$100 & Book/i }));
+        fireEvent.click(screen.getByRole('button', { name: /Confirm \$100 booking/i }));
 
         // Wait for step 4 success page
         await waitFor(() => {
@@ -185,7 +184,6 @@ describe('BookingCheckoutWizard', () => {
             expect(mockBookFlightAction).toHaveBeenCalledTimes(1);
             expect(mockBookFlightAction).toHaveBeenCalledWith({
                 flightId: 42,
-                totalPrice: '$100',
                 passengers: [{
                     firstName: 'Bob',
                     lastName: 'Jones',
@@ -195,12 +193,12 @@ describe('BookingCheckoutWizard', () => {
                     seatNumber: '11C',
                     cabinClass: 'ECONOMY'
                 }],
-                paymentIntentId: expect.any(String)
+                idempotencyKey: expect.stringMatching(/^[0-9a-f-]{36}$/i)
             });
         });
 
         // Verify Boarding Pass renders details
-        expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+        expect(screen.getByText('Robert Jones')).toBeInTheDocument();
         expect(screen.getByText('GA404')).toBeInTheDocument();
         expect(screen.getByText('11C')).toBeInTheDocument();
         expect(screen.getByText('ECONOMY')).toBeInTheDocument();
@@ -221,21 +219,68 @@ describe('BookingCheckoutWizard', () => {
         fireEvent.click(screen.getByText('Select Seats →'));
         fireEvent.click(screen.getByTitle('Select Seat 11D'));
 
-        // Payment Step
-        fireEvent.click(screen.getByText('Billing & Summary →'));
-
-        // Fill card info
-        fireEvent.change(screen.getByPlaceholderText('4111 2222 3333 4444'), { target: { value: '4111222233334444' } });
-        fireEvent.change(screen.getByPlaceholderText('JOHN DOE'), { target: { value: 'JOHN DOE' } });
-        fireEvent.change(screen.getByPlaceholderText('MM/YY'), { target: { value: '09/27' } });
-        fireEvent.change(screen.getByPlaceholderText('123'), { target: { value: '321' } });
+        // Review Step
+        fireEvent.click(screen.getByText('Review Booking →'));
 
         // Submit Booking
-        fireEvent.click(screen.getByRole('button', { name: /Pay \$100 & Book/i }));
+        fireEvent.click(screen.getByRole('button', { name: /Confirm \$100 booking/i }));
 
         // Check if error is displayed
         await waitFor(() => {
             expect(screen.getByText(/Seats already taken!/i)).toBeInTheDocument();
+        });
+    });
+
+    it('announces and visibly disables the confirmation action while booking', async () => {
+        let resolveBooking!: (value: {
+            id: number;
+            totalPrice: string;
+            passengers: Array<{ firstName: string; lastName: string; seatNumber: string; cabinClass: string }>;
+        }) => void;
+        mockBookFlightAction.mockImplementation(() => new Promise((resolve) => {
+            resolveBooking = resolve;
+        }));
+
+        const { container } = render(<BookingCheckoutWizard flight={sampleFlight} occupiedSeats={[]} />);
+        fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Bob' } });
+        fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Jones' } });
+        fireEvent.change(container.querySelector('input[type="date"]')!, { target: { value: '1988-12-01' } });
+        fireEvent.change(screen.getByPlaceholderText('A00000000'), { target: { value: 'US9876543' } });
+        fireEvent.click(screen.getByText('Select Seats →'));
+        fireEvent.click(screen.getByTitle('Select Seat 11C'));
+        fireEvent.click(screen.getByText('Review Booking →'));
+
+        fireEvent.click(screen.getByRole('button', { name: /Confirm \$100 booking/i }));
+
+        const pendingButton = screen.getByRole('button', { name: /Confirming Booking/i });
+        expect(pendingButton).toBeDisabled();
+        expect(pendingButton).toHaveAttribute('aria-busy', 'true');
+        expect(pendingButton).toHaveStyle({ opacity: '0.65', cursor: 'not-allowed' });
+        expect(screen.getByRole('status')).toHaveTextContent('Confirming booking and checking availability.');
+
+        resolveBooking({
+            id: 12345,
+            totalPrice: '$100',
+            passengers: [{ firstName: 'Bob', lastName: 'Jones', seatNumber: '11C', cabinClass: 'ECONOMY' }]
+        });
+        await waitFor(() => expect(screen.getByText('Booking Confirmed!')).toBeInTheDocument());
+    });
+
+    it('uses booking-specific copy for an unknown submission failure', async () => {
+        mockBookFlightAction.mockRejectedValue('network failure');
+
+        const { container } = render(<BookingCheckoutWizard flight={sampleFlight} occupiedSeats={[]} />);
+        fireEvent.change(screen.getByPlaceholderText('John'), { target: { value: 'Bob' } });
+        fireEvent.change(screen.getByPlaceholderText('Doe'), { target: { value: 'Jones' } });
+        fireEvent.change(container.querySelector('input[type="date"]')!, { target: { value: '1988-12-01' } });
+        fireEvent.change(screen.getByPlaceholderText('A00000000'), { target: { value: 'US9876543' } });
+        fireEvent.click(screen.getByText('Select Seats →'));
+        fireEvent.click(screen.getByTitle('Select Seat 11C'));
+        fireEvent.click(screen.getByText('Review Booking →'));
+        fireEvent.click(screen.getByRole('button', { name: /Confirm \$100 booking/i }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert')).toHaveTextContent('We couldn’t confirm your booking. Please try again.');
         });
     });
 
@@ -257,12 +302,8 @@ describe('BookingCheckoutWizard', () => {
         fireEvent.change(screen.getByPlaceholderText('A00000000'), { target: { value: 'US9876543' } });
         fireEvent.click(screen.getByText('Select Seats →'));
         fireEvent.click(screen.getByTitle('Select Seat 11C'));
-        fireEvent.click(screen.getByText('Billing & Summary →'));
-        fireEvent.change(screen.getByPlaceholderText('4111 2222 3333 4444'), { target: { value: '4111222233334444' } });
-        fireEvent.change(screen.getByPlaceholderText('JOHN DOE'), { target: { value: 'BOB JONES' } });
-        fireEvent.change(screen.getByPlaceholderText('MM/YY'), { target: { value: '12/29' } });
-        fireEvent.change(screen.getByPlaceholderText('123'), { target: { value: '123' } });
-        fireEvent.click(screen.getByRole('button', { name: /Pay \$100 & Book/i }));
+        fireEvent.click(screen.getByText('Review Booking →'));
+        fireEvent.click(screen.getByRole('button', { name: /Confirm \$100 booking/i }));
 
         await waitFor(() => expect(screen.getByText('Traveler Information')).toBeInTheDocument());
         expect(screen.getByRole('alert')).toHaveTextContent('First name is required.');
@@ -289,12 +330,8 @@ describe('BookingCheckoutWizard', () => {
         fireEvent.change(screen.getByPlaceholderText('A00000000'), { target: { value: 'US9876543' } });
         fireEvent.click(screen.getByText('Select Seats →'));
         fireEvent.click(screen.getByTitle('Select Seat 11C'));
-        fireEvent.click(screen.getByText('Billing & Summary →'));
-        fireEvent.change(screen.getByPlaceholderText('4111 2222 3333 4444'), { target: { value: '4111222233334444' } });
-        fireEvent.change(screen.getByPlaceholderText('JOHN DOE'), { target: { value: 'BOB JONES' } });
-        fireEvent.change(screen.getByPlaceholderText('MM/YY'), { target: { value: '12/29' } });
-        fireEvent.change(screen.getByPlaceholderText('123'), { target: { value: '123' } });
-        fireEvent.click(screen.getByRole('button', { name: /Pay \$100 & Book/i }));
+        fireEvent.click(screen.getByText('Review Booking →'));
+        fireEvent.click(screen.getByRole('button', { name: /Confirm \$100 booking/i }));
 
         await waitFor(() => expect(screen.getByText('Select Your Seats')).toBeInTheDocument());
         const passengerTarget = screen.getByRole('button', { name: /Bob Jones.*Seat: 11C/i });

--- a/__tests__/lib/FlightBookingService.test.ts
+++ b/__tests__/lib/FlightBookingService.test.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/lib/prisma';
 const mockTx = {
     $queryRaw: jest.fn(),
     booking: {
+        findFirst: jest.fn(),
         findMany: jest.fn(),
         create: jest.fn(),
     },
@@ -23,6 +24,7 @@ describe('FlightBookingService', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockTx.booking.findMany.mockReset();
+        mockTx.booking.findFirst.mockReset();
         mockTx.booking.create.mockReset();
         mockTx.flight.findUnique.mockReset();
         mockTx.$queryRaw.mockReset();
@@ -36,15 +38,19 @@ describe('FlightBookingService', () => {
         expect(mockTx.booking.create).not.toHaveBeenCalled();
     });
 
-    it('creates a detailed booking with passengers and validates seat selections', async () => {
+    it('calculates price from the locked flight and selected cabins', async () => {
         mockTx.flight.findUnique.mockResolvedValue({
             id: 7,
+            price: '$350',
+            status: 'ON_TIME',
+            departureDate: new Date('2099-01-01T10:00:00Z'),
             firstClassRows: 2,
             businessRows: 4,
             premiumEconomyRows: 4,
             economyRows: 20,
             seatPattern: 'ABC-DEF'
         });
+        mockTx.booking.findFirst.mockResolvedValue(null);
         mockTx.booking.findMany.mockResolvedValue([
             {
                 id: 10,
@@ -59,13 +65,14 @@ describe('FlightBookingService', () => {
             id: 2,
             flightId: 7,
             userId: 'u1',
-            totalPrice: '$525',
+            totalPrice: '$700',
+            paymentIntentId: null,
             passengers: [
                 {
                     firstName: 'Alice',
                     lastName: 'Smith',
-                    seatNumber: '12C',
-                    cabinClass: 'ECONOMY'
+                    seatNumber: '4C',
+                    cabinClass: 'BUSINESS'
                 }
             ]
         });
@@ -77,17 +84,24 @@ describe('FlightBookingService', () => {
                 dateOfBirth: '1995-05-15',
                 passportNumber: 'US123456',
                 gender: 'Female',
-                seatNumber: '12C',
-                cabinClass: 'ECONOMY'
+                seatNumber: '4C',
+                cabinClass: 'BUSINESS'
             }
         ];
 
         const result = await new FlightBookingService().bookFlight({
             flightId: 7,
             userId: 'u1',
-            totalPrice: '$525',
             passengers: passengersList,
-            paymentIntentId: 'mock_intent_123'
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
+        });
+
+        expect(mockTx.booking.findFirst).toHaveBeenCalledWith({
+            where: {
+                userId: 'u1',
+                idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
+            },
+            include: { passengers: true }
         });
 
         expect(mockTx.booking.findMany).toHaveBeenCalledWith({
@@ -99,8 +113,9 @@ describe('FlightBookingService', () => {
             data: {
                 flightId: 7,
                 userId: 'u1',
-                totalPrice: '$525',
-                paymentIntentId: 'mock_intent_123',
+                totalPrice: '$700',
+                paymentIntentId: null,
+                idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735',
                 passengers: {
                     create: [
                         {
@@ -109,8 +124,8 @@ describe('FlightBookingService', () => {
                             dateOfBirth: new Date('1995-05-15'),
                             passportNumber: 'US123456',
                             gender: 'Female',
-                            seatNumber: '12C',
-                            cabinClass: 'ECONOMY',
+                            seatNumber: '4C',
+                            cabinClass: 'BUSINESS',
                             flightId: 7
                         }
                     ]
@@ -119,12 +134,113 @@ describe('FlightBookingService', () => {
             include: { passengers: true }
         });
 
-        expect(result).toMatchObject({ id: 2, totalPrice: '$525' });
+        expect(result).toMatchObject({ id: 2, totalPrice: '$700' });
+    });
+
+    it('returns the existing booking when an idempotency key is retried', async () => {
+        const existing = {
+            id: 12,
+            userId: 'u1',
+            flightId: 7,
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735',
+            totalPrice: '$350',
+            passengers: [{
+                firstName: 'Alice', lastName: 'Smith', dateOfBirth: new Date('1995-05-15T00:00:00.000Z'),
+                passportNumber: 'US123456', gender: 'Female', seatNumber: '11A', cabinClass: 'ECONOMY'
+            }]
+        };
+        mockTx.flight.findUnique.mockResolvedValue({
+            id: 7,
+            price: '$350',
+            status: 'ON_TIME',
+            departureDate: new Date('2099-01-01T10:00:00Z')
+        });
+        mockTx.booking.findFirst.mockResolvedValue(existing);
+
+        const result = await new FlightBookingService().bookFlight({
+            flightId: 7,
+            userId: 'u1',
+            passengers: [{
+                firstName: 'Alice', lastName: 'Smith', dateOfBirth: '1995-05-15',
+                passportNumber: 'US123456', gender: 'Female', seatNumber: '11A',
+                cabinClass: 'ECONOMY'
+            }],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
+        });
+
+        expect(result).toEqual({ ...existing, wasCreated: false });
+        expect(mockTx.booking.create).not.toHaveBeenCalled();
+        expect(mockTx.booking.findMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects reuse of an idempotency key for a different flight or passenger request', async () => {
+        const existing = {
+            id: 12,
+            userId: 'u1',
+            flightId: 8,
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735',
+            totalPrice: '$350',
+            passengers: [{
+                firstName: 'Alice', lastName: 'Smith', dateOfBirth: new Date('1995-05-15T00:00:00.000Z'),
+                passportNumber: 'US123456', gender: 'Female', seatNumber: '11A', cabinClass: 'ECONOMY'
+            }]
+        };
+        mockTx.flight.findUnique.mockResolvedValue({
+            id: 7, price: '$350', status: 'ON_TIME', departureDate: new Date('2099-01-01T10:00:00Z')
+        });
+        mockTx.booking.findFirst.mockResolvedValue(existing);
+        const request = {
+            flightId: 7,
+            userId: 'u1',
+            passengers: [{
+                firstName: 'Alice', lastName: 'Smith', dateOfBirth: '1995-05-15',
+                passportNumber: 'US123456', gender: 'Female', seatNumber: '11A', cabinClass: 'ECONOMY'
+            }],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
+        };
+
+        await expect(new FlightBookingService().bookFlight(request))
+            .rejects.toThrow('Booking request ID was already used for a different booking.');
+
+        existing.flightId = 7;
+        request.passengers[0].seatNumber = '11B';
+        await expect(new FlightBookingService().bookFlight(request))
+            .rejects.toThrow('Booking request ID was already used for a different booking.');
+        expect(mockTx.booking.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects cancelled and departed flight inventory', async () => {
+        const request = {
+            flightId: 7,
+            userId: 'u1',
+            passengers: [{
+                firstName: 'Alice', lastName: 'Smith', dateOfBirth: '1995-05-15',
+                passportNumber: 'US123456', gender: 'Female', seatNumber: '11A',
+                cabinClass: 'ECONOMY'
+            }],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
+        };
+        mockTx.booking.findFirst.mockResolvedValue(null);
+        mockTx.flight.findUnique.mockResolvedValue({
+            id: 7, price: '$350', status: 'CANCELLED', departureDate: new Date('2099-01-01T10:00:00Z')
+        });
+        await expect(new FlightBookingService().bookFlight(request))
+            .rejects.toThrow('Flight is not available for booking.');
+
+        mockTx.flight.findUnique.mockResolvedValue({
+            id: 7, price: '$350', status: 'ON_TIME', departureDate: new Date('2020-01-01T10:00:00Z')
+        });
+        await expect(new FlightBookingService().bookFlight(request))
+            .rejects.toThrow('Flight is not available for booking.');
+        expect(mockTx.booking.create).not.toHaveBeenCalled();
     });
 
     it('rejects seats outside the configured cabin layout', async () => {
         mockTx.flight.findUnique.mockResolvedValue({
             id: 7,
+            price: '$350',
+            status: 'ON_TIME',
+            departureDate: new Date('2099-01-01T10:00:00Z'),
             firstClassRows: 1,
             businessRows: 1,
             premiumEconomyRows: 1,
@@ -146,20 +262,26 @@ describe('FlightBookingService', () => {
         await expect(new FlightBookingService().bookFlight({
             flightId: 7,
             userId: 'u1',
-            passengers: [passenger]
+            passengers: [passenger],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         })).rejects.toThrow('Seat 1A is not available for ECONOMY on this flight.');
 
         passenger.seatNumber = '8F';
         await expect(new FlightBookingService().bookFlight({
             flightId: 7,
             userId: 'u1',
-            passengers: [passenger]
+            passengers: [passenger],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         })).rejects.toThrow('Seat 8F is not available for ECONOMY on this flight.');
         expect(mockTx.booking.create).not.toHaveBeenCalled();
     });
 
     it('rejects duplicate seats within one booking request', async () => {
-        mockTx.flight.findUnique.mockResolvedValue({ id: 7 });
+        mockTx.flight.findUnique.mockResolvedValue({
+            id: 7, price: '$350', status: 'ON_TIME',
+            departureDate: new Date('2099-01-01T10:00:00Z')
+        });
+        mockTx.booking.findFirst.mockResolvedValue(null);
         mockTx.booking.findMany.mockResolvedValue([]);
         const passenger = {
             firstName: 'Alice',
@@ -174,13 +296,18 @@ describe('FlightBookingService', () => {
         await expect(new FlightBookingService().bookFlight({
             flightId: 7,
             userId: 'u1',
-            passengers: [passenger, { ...passenger, firstName: 'Bob' }]
+            passengers: [passenger, { ...passenger, firstName: 'Bob' }],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         })).rejects.toThrow('Duplicate seats selected in request.');
         expect(mockTx.booking.create).not.toHaveBeenCalled();
     });
 
     it('throws an error if a requested seat is already occupied', async () => {
-        mockTx.flight.findUnique.mockResolvedValue({ id: 7 });
+        mockTx.flight.findUnique.mockResolvedValue({
+            id: 7, price: '$350', status: 'ON_TIME',
+            departureDate: new Date('2099-01-01T10:00:00Z')
+        });
+        mockTx.booking.findFirst.mockResolvedValue(null);
         mockTx.booking.findMany.mockResolvedValue([
             {
                 id: 10,
@@ -206,10 +333,27 @@ describe('FlightBookingService', () => {
         await expect(new FlightBookingService().bookFlight({
             flightId: 7,
             userId: 'u1',
-            totalPrice: '$350',
-            passengers: passengersList
+            passengers: passengersList,
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         })).rejects.toThrow('Seat 12A is already occupied on this flight.');
 
         expect(mockTx.booking.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects client-supplied prices and payment identifiers', async () => {
+        await expect(new FlightBookingService().bookFlight({
+            flightId: 7,
+            userId: 'u1',
+            passengers: [{
+                firstName: 'Alice', lastName: 'Smith', dateOfBirth: '1995-05-15',
+                passportNumber: 'US123456', gender: 'Female', seatNumber: '11A',
+                cabinClass: 'ECONOMY'
+            }],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735',
+            totalPrice: '$0.01',
+            paymentIntentId: 'forged'
+        } as any)).rejects.toThrow('Unrecognized');
+
+        expect(prisma.$transaction).not.toHaveBeenCalled();
     });
 });

--- a/__tests__/lib/PointsActivityService.test.ts
+++ b/__tests__/lib/PointsActivityService.test.ts
@@ -98,6 +98,19 @@ describe('PointsActivityService dynamic calculations', () => {
         expect(activities[0].points).toBe(450);
     });
 
+    it('awards whole-dollar points for authoritative decimal fares', () => {
+        const service = new PointsActivityService([{
+            id: 4,
+            createdAt: new Date('2026-03-11'),
+            status: 'CONFIRMED',
+            totalPrice: '$69.97',
+            flight: null
+        } as any], 500);
+
+        expect(service.getCurrentPoints()).toBe(569);
+        expect(service.getPointsActivity()[0].points).toBe(69);
+    });
+
     it('correctly handles CANCELLED bookings by not counting points and rendering negative log rows', () => {
         const bookingsWithCancelled: any[] = [
             {

--- a/__tests__/lib/bookingPricing.test.ts
+++ b/__tests__/lib/bookingPricing.test.ts
@@ -1,0 +1,26 @@
+/** @jest-environment node */
+import { calculateBookingTotal, parsePriceToCents } from '@/lib/bookingPricing';
+
+describe('authoritative booking pricing', () => {
+    it('calculates cabin fares from the stored base price in integer cents', () => {
+        expect(calculateBookingTotal('$350', [
+            { cabinClass: 'ECONOMY' },
+            { cabinClass: 'PREMIUM_ECONOMY' },
+            { cabinClass: 'BUSINESS' },
+            { cabinClass: 'FIRST' }
+        ])).toEqual({ cents: 2_625_00, formatted: '$2,625' });
+    });
+
+    it('preserves cents without floating-point drift', () => {
+        expect(calculateBookingTotal('$19.99', [
+            { cabinClass: 'PREMIUM_ECONOMY' },
+            { cabinClass: 'BUSINESS' }
+        ])).toEqual({ cents: 6_997, formatted: '$69.97' });
+    });
+
+    it('rejects malformed, negative, and unsupported prices', () => {
+        expect(() => parsePriceToCents('free')).toThrow('Flight price is invalid.');
+        expect(() => parsePriceToCents('-$10')).toThrow('Flight price is invalid.');
+        expect(() => parsePriceToCents('$10.999')).toThrow('Flight price is invalid.');
+    });
+});

--- a/__tests__/lib/validation.test.ts
+++ b/__tests__/lib/validation.test.ts
@@ -125,16 +125,19 @@ describe('shared server validation schemas', () => {
             .toBe(false);
         expect(bookingRequestSchema.safeParse({
             flightId: 1,
-            passengers: Array.from({ length: 9 }, () => passenger)
+            passengers: Array.from({ length: 9 }, () => passenger),
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         }).success).toBe(true);
         expect(bookingRequestSchema.safeParse({
             flightId: 1,
-            passengers: Array.from({ length: 10 }, () => passenger)
+            passengers: Array.from({ length: 10 }, () => passenger),
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         }).success).toBe(false);
         expect(flightBookingServiceSchema.safeParse({
             flightId: 1,
             userId: 'user-1',
-            passengers: [passenger]
+            passengers: [passenger],
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         }).success).toBe(true);
         expect(flightBookingServiceSchema.safeParse({ flightId: 1, userId: '' }).success)
             .toBe(false);
@@ -253,9 +256,27 @@ describe('shared server validation schemas', () => {
         const passengers = Array.from({ length: 9 }, (_, index) => ({
             ...passenger, passportNumber: `P${index}`, seatNumber: `${index + 1}A`
         }));
-        expect(bookingRequestSchema.safeParse({ flightId: 1, passengers }).success).toBe(true);
-        expect(bookingRequestSchema.safeParse({ flightId: 1, passengers: [] }).success).toBe(false);
-        expect(bookingRequestSchema.safeParse({ flightId: 1, passengers: [...passengers, passenger] }).success).toBe(false);
+        const idempotencyKey = '8ea59a65-9251-45b3-95d0-3920c49f5735';
+        expect(bookingRequestSchema.safeParse({ flightId: 1, passengers, idempotencyKey }).success).toBe(true);
+        expect(bookingRequestSchema.safeParse({ flightId: 1, passengers: [], idempotencyKey }).success).toBe(false);
+        expect(bookingRequestSchema.safeParse({ flightId: 1, passengers: [...passengers, passenger], idempotencyKey }).success).toBe(false);
+        expect(bookingRequestSchema.safeParse({
+            flightId: 1,
+            passengers,
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
+        }).success).toBe(true);
+        expect(bookingRequestSchema.safeParse({
+            flightId: 1,
+            passengers,
+            idempotencyKey: 'not-a-uuid'
+        }).success).toBe(false);
+        expect(bookingRequestSchema.safeParse({
+            flightId: 1,
+            passengers,
+            idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735',
+            totalPrice: '$1',
+            paymentIntentId: 'forged'
+        }).success).toBe(false);
 
         const seatChanges = Array.from({ length: 9 }, (_, index) => ({ passengerId: `p${index}`, seatNumber: `${index + 1}A` }));
         expect(seatChangesSchema.safeParse({ bookingId: 1, seatChanges }).success).toBe(true);

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -12,6 +12,7 @@ import { assertSeatAvailableForCabin, validateSeatingLayout } from '@/lib/seatLa
 import { lockFlightForUpdate } from '@/lib/flightLock';
 import { updateFlightSeatingLayout } from '@/lib/FlightSeatLayoutService';
 import { actionValidationFailure } from '@/lib/actionResult';
+import { parsePriceToCents } from '@/lib/bookingPricing';
 import {
     bookingRequestSchema,
     cityGuideSchema,
@@ -107,10 +108,9 @@ export async function getFlightRoutesAction() {
 }
 
 export async function bookFlightAction(bookingData: { 
-    flightId: number; 
-    totalPrice?: string; 
+    flightId: number;
     passengers: PassengerInput[];
-    paymentIntentId?: string; 
+    idempotencyKey: string;
 }) {
     const session = await getServerSession(authOptions);
     const userId = session?.user?.id;
@@ -122,16 +122,14 @@ export async function bookFlightAction(bookingData: {
     const result = await flightBookingService.bookFlight({
         flightId: bookingData.flightId,
         userId,
-        totalPrice: bookingData.totalPrice,
         passengers: bookingData.passengers,
-        paymentIntentId: bookingData.paymentIntentId
+        idempotencyKey: bookingData.idempotencyKey
     });
 
     try {
         const flight = await prisma.flight.findUnique({ where: { id: bookingData.flightId } });
-        if (flight) {
-            const rawPrice = bookingData.totalPrice || flight.price;
-            const points = parseInt(rawPrice.replace(/[^0-9]/g, ""), 10) || 0;
+        if (flight && result.wasCreated) {
+            const points = Math.floor(parsePriceToCents(result.totalPrice) / 100);
             await prisma.notification.create({
                 data: {
                     userId,
@@ -256,7 +254,7 @@ export async function cancelBookingAction(bookingId: number) {
         const flight = booking.flight;
         if (flight && booking.userId) {
             const rawPrice = booking.totalPrice || flight.price;
-            const points = parseInt(rawPrice.replace(/[^0-9]/g, ""), 10) || 0;
+            const points = Math.floor(parsePriceToCents(rawPrice) / 100);
             await prisma.notification.create({
                 data: {
                     userId: booking.userId,

--- a/app/globals.css
+++ b/app/globals.css
@@ -522,6 +522,49 @@ footer a:hover {
   border: 0 !important;
 }
 
+.booking-wizard-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.booking-traveler-primary-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.booking-seat-actions,
+.booking-review-actions {
+  margin-top: 2.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 1.5rem;
+}
+
+.booking-success-actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+@media (max-width: 480px) {
+  .booking-wizard-actions,
+  .booking-traveler-primary-actions,
+  .booking-success-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .booking-wizard-actions button,
+  .booking-success-actions > a {
+    box-sizing: border-box;
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+}
+
 /* Custom Scrollbar for premium feel */
 ::-webkit-scrollbar {
   width: 8px;

--- a/components/ui/BookingCheckoutWizard.tsx
+++ b/components/ui/BookingCheckoutWizard.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Link from 'next/link';
 import { PassengerInput } from '@/lib/FlightBookingService';
 import { bookFlightAction } from '@/app/actions';
 import { isActionValidationFailure } from '@/lib/actionResult';
+import { CABIN_FARE_PERCENT, calculatePassengerFareCents, formatPrice, parsePriceToCents } from '@/lib/bookingPricing';
 
 interface Flight {
     id: number;
@@ -36,12 +37,12 @@ interface PassengerFormState {
     seatNumber: string;
 }
 
-const CABIN_MULTIPLIERS = {
-    ECONOMY: 1.0,
-    PREMIUM_ECONOMY: 1.5,
-    BUSINESS: 2.0,
-    FIRST: 3.0
-};
+interface ConfirmedPassenger {
+    firstName: string;
+    lastName: string;
+    seatNumber: string;
+    cabinClass: string;
+}
 
 const CABIN_LABELS = {
     ECONOMY: 'Economy',
@@ -50,15 +51,24 @@ const CABIN_LABELS = {
     FIRST: 'First Class (+200%)'
 };
 
+function createBookingRequestId(): string {
+    const bytes = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOccupiedSeats }: BookingCheckoutWizardProps) {
-    const basePriceNum = parseInt(flight.price.replace(/[^0-9]/g, ""), 10) || 0;
+    const basePriceCents = parsePriceToCents(flight.price);
     const cabinRowCounts: Record<PassengerFormState['cabinClass'], number> = {
         ECONOMY: flight.economyRows ?? 20,
         PREMIUM_ECONOMY: flight.premiumEconomyRows ?? 4,
         BUSINESS: flight.businessRows ?? 3,
         FIRST: flight.firstClassRows ?? 3
     };
-    const availableCabins = (Object.keys(CABIN_MULTIPLIERS) as PassengerFormState['cabinClass'][])
+    const availableCabins = (Object.keys(CABIN_FARE_PERCENT) as PassengerFormState['cabinClass'][])
         .filter(cabin => cabinRowCounts[cabin] > 0);
     const defaultCabin = availableCabins[0];
 
@@ -75,20 +85,25 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
         }
     ]);
     const [activePassengerIndex, setActivePassengerIndex] = useState<number>(0);
-    const [paymentCard, setPaymentCard] = useState({ number: '', name: '', expiry: '', cvv: '' });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [serverFieldErrors, setServerFieldErrors] = useState<Record<string, string[]>>({});
-    const [bookingResult, setBookingResult] = useState<{ id: number; paymentIntentId: string } | null>(null);
+    const [bookingResult, setBookingResult] = useState<{
+        id: number;
+        totalPrice: string;
+        passengers: ConfirmedPassenger[];
+    } | null>(null);
+    const idempotencyKeyRef = useRef<string | null>(null);
     const [autoAllocateGroup, setAutoAllocateGroup] = useState<boolean>(true);
     const [hoveredSuggestedSeats, setHoveredSuggestedSeats] = useState<string[]>([]);
 
     // Calculate total price
     const calculatePassengerPrice = (cabin: 'ECONOMY' | 'PREMIUM_ECONOMY' | 'BUSINESS' | 'FIRST') => {
-        return Math.round(basePriceNum * CABIN_MULTIPLIERS[cabin]);
+        return calculatePassengerFareCents(basePriceCents, cabin);
     };
 
-    const totalPrice = passengers.reduce((sum, p) => sum + calculatePassengerPrice(p.cabinClass), 0);
+    const totalPriceCents = passengers.reduce((sum, p) => sum + calculatePassengerPrice(p.cabinClass), 0);
+    const totalPriceDisplay = formatPrice(totalPriceCents);
 
     const handleAddPassenger = () => {
         setPassengers([
@@ -155,28 +170,6 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                 setErrorMessage(`Please select a seat for Passenger ${i + 1}.`);
                 return false;
             }
-        }
-        setErrorMessage(null);
-        return true;
-    };
-
-    const validateStep3 = () => {
-        const { number, name, expiry, cvv } = paymentCard;
-        if (!number.replace(/\s/g, '').match(/^\d{16}$/)) {
-            setErrorMessage('Card number must be 16 digits.');
-            return false;
-        }
-        if (!name.trim()) {
-            setErrorMessage('Cardholder name is required.');
-            return false;
-        }
-        if (!expiry.match(/^(0[1-9]|1[0-2])\/?([0-9]{2})$/)) {
-            setErrorMessage('Expiry date must be MM/YY format.');
-            return false;
-        }
-        if (!cvv.match(/^\d{3,4}$/)) {
-            setErrorMessage('CVV must be 3 or 4 digits.');
-            return false;
         }
         setErrorMessage(null);
         return true;
@@ -466,7 +459,6 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
     };
 
     const handleSubmitBooking = async () => {
-        if (!validateStep3()) return;
         setIsSubmitting(true);
         setErrorMessage(null);
         setServerFieldErrors({});
@@ -482,11 +474,11 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                 cabinClass: p.cabinClass
             }));
 
+            idempotencyKeyRef.current ??= createBookingRequestId();
             const result = await bookFlightAction({
                 flightId: flight.id,
-                totalPrice: `$${totalPrice}`,
                 passengers: formattedPassengers,
-                paymentIntentId: `ch_${Math.random().toString(36).substr(2, 9)}`
+                idempotencyKey: idempotencyKeyRef.current
             });
 
             if (isActionValidationFailure(result)) {
@@ -510,11 +502,17 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
 
             setBookingResult({
                 id: result.id,
-                paymentIntentId: result.paymentIntentId || ''
+                totalPrice: result.totalPrice,
+                passengers: result.passengers.map(passenger => ({
+                    firstName: passenger.firstName,
+                    lastName: passenger.lastName,
+                    seatNumber: passenger.seatNumber,
+                    cabinClass: passenger.cabinClass
+                }))
             });
             setStep(4);
         } catch (error: unknown) {
-            const msg = error instanceof Error ? error.message : 'Payment processing failed. Please try again.';
+            const msg = error instanceof Error ? error.message : 'We couldn’t confirm your booking. Please try again.';
             setErrorMessage(msg);
         } finally {
             setIsSubmitting(false);
@@ -529,7 +527,7 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                 {[
                     { s: 1, label: 'Travelers' },
                     { s: 2, label: 'Seats' },
-                    { s: 3, label: 'Payment' },
+                    { s: 3, label: 'Review' },
                     { s: 4, label: 'E-Ticket' }
                 ].map((item) => (
                     <div key={item.s} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', zIndex: 2, flex: 1 }}>
@@ -678,7 +676,7 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                             </div>
                         ))}
 
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '2rem' }}>
+                        <div className="booking-wizard-actions booking-traveler-actions">
                             <button
                                 type="button"
                                 onClick={handleAddPassenger}
@@ -686,8 +684,8 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                 + Add Traveler
                             </button>
 
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '1.5rem' }}>
-                                <span style={{ fontSize: '1.1rem', color: '#34d399', fontWeight: 'bold' }}>Total: ${totalPrice.toLocaleString()}</span>
+                            <div className="booking-traveler-primary-actions">
+                                <span style={{ fontSize: '1.1rem', color: '#34d399', fontWeight: 'bold' }}>Estimated total: {totalPriceDisplay}</span>
                                 <button
                                     type="button"
                                     onClick={handleNextStep}
@@ -985,7 +983,7 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                             </div>
                         </div>
 
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '2.5rem', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '1.5rem' }}>
+                        <div className="booking-wizard-actions booking-seat-actions">
                             <button
                                 type="button"
                                 onClick={handlePrevStep}
@@ -996,19 +994,19 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                 type="button"
                                 onClick={handleNextStep}
                                 style={{ backgroundColor: '#8b5cf6', color: '#fff', border: 'none', padding: '10px 28px', borderRadius: '8px', cursor: 'pointer', fontWeight: 'bold' }}>
-                                Billing & Summary →
+                                Review Booking →
                             </button>
                         </div>
                     </div>
                 )}
 
-                {/* STEP 3: BILLING & PAYMENT */}
+                {/* STEP 3: BOOKING REVIEW */}
                 {step === 3 && (
                     <div>
-                        <h2 style={{ fontSize: '1.8rem', color: '#c084fc', marginBottom: '0.5rem', fontWeight: 'bold' }}>Review & Purchase</h2>
-                        <p style={{ color: 'rgba(255,255,255,0.5)', marginBottom: '2rem' }}>Please verify your details and enter card information to complete the booking.</p>
+                        <h2 style={{ fontSize: '1.8rem', color: '#c084fc', marginBottom: '0.5rem', fontWeight: 'bold' }}>Review Booking</h2>
+                        <p style={{ color: 'rgba(255,255,255,0.5)', marginBottom: '2rem' }}>Verify the itinerary and traveler details before confirming.</p>
 
-                        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '2rem', marginBottom: '2rem' }}>
+                        <div style={{ marginBottom: '2rem' }}>
                             {/* Summary list */}
                             <div style={{ border: '1px solid rgba(255, 255, 255, 0.08)', borderRadius: '12px', padding: '1.5rem', background: 'rgba(0,0,0,0.15)' }}>
                                 <h3 style={{ margin: '0 0 1rem', fontSize: '1.1rem', color: '#a78bfa' }}>Trip Summary</h3>
@@ -1029,71 +1027,27 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                                 <strong>{p.firstName} {p.lastName}</strong>
                                                 <div style={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.5)' }}>Class: {p.cabinClass} | Seat: {p.seatNumber}</div>
                                             </div>
-                                            <span style={{ fontWeight: 'bold' }}>${calculatePassengerPrice(p.cabinClass)}</span>
+                                            <span style={{ fontWeight: 'bold' }}>{formatPrice(calculatePassengerPrice(p.cabinClass))}</span>
                                         </div>
                                     ))}
                                 </div>
 
                                 <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '1.2rem', fontWeight: 'bold', borderTop: '1px solid rgba(255,255,255,0.08)', marginTop: '1.25rem', paddingTop: '1rem', color: '#34d399' }}>
-                                    <span>Total Price</span>
-                                    <span>${totalPrice.toLocaleString()}</span>
+                                    <span>Estimated Total</span>
+                                    <span>{totalPriceDisplay}</span>
                                 </div>
                             </div>
-
-                            {/* Payment card entry fields */}
-                            <div>
-                                <h3 style={{ margin: '0 0 1rem', fontSize: '1.1rem', color: '#a78bfa' }}>Payment Details</h3>
-                                <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-                                    <div>
-                                        <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '4px', color: 'rgba(255,255,255,0.7)' }}>Card Number</label>
-                                        <input
-                                            type="text"
-                                            value={paymentCard.number}
-                                            onChange={(e) => setPaymentCard({ ...paymentCard, number: e.target.value.replace(/[^0-9]/g, '').replace(/(\d{4})(?=\d)/g, '$1 ') })}
-                                            placeholder="4111 2222 3333 4444"
-                                            maxLength={19}
-                                            style={{ width: '100%', padding: '10px 12px', borderRadius: '6px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#fff' }}
-                                        />
-                                    </div>
-                                    <div>
-                                        <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '4px', color: 'rgba(255,255,255,0.7)' }}>Cardholder Name</label>
-                                        <input
-                                            type="text"
-                                            value={paymentCard.name}
-                                            onChange={(e) => setPaymentCard({ ...paymentCard, name: e.target.value })}
-                                            placeholder="JOHN DOE"
-                                            style={{ width: '100%', padding: '10px 12px', borderRadius: '6px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#fff' }}
-                                        />
-                                    </div>
-                                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
-                                        <div>
-                                            <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '4px', color: 'rgba(255,255,255,0.7)' }}>Expiry Date</label>
-                                            <input
-                                                type="text"
-                                                value={paymentCard.expiry}
-                                                onChange={(e) => setPaymentCard({ ...paymentCard, expiry: e.target.value })}
-                                                placeholder="MM/YY"
-                                                maxLength={5}
-                                                style={{ width: '100%', padding: '10px 12px', borderRadius: '6px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#fff' }}
-                                            />
-                                        </div>
-                                        <div>
-                                            <label style={{ display: 'block', fontSize: '0.85rem', marginBottom: '4px', color: 'rgba(255,255,255,0.7)' }}>CVV</label>
-                                            <input
-                                                type="password"
-                                                value={paymentCard.cvv}
-                                                onChange={(e) => setPaymentCard({ ...paymentCard, cvv: e.target.value.replace(/[^0-9]/g, '') })}
-                                                placeholder="123"
-                                                maxLength={4}
-                                                style={{ width: '100%', padding: '10px 12px', borderRadius: '6px', background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: '#fff' }}
-                                            />
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            <p role="note" style={{ color: 'rgba(255,255,255,0.65)', margin: '1rem 0 0', fontSize: '0.9rem' }}>
+                                Payment is not collected in this demo. The server will confirm the current fare and seat availability when you book.
+                            </p>
                         </div>
 
-                        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '2.5rem', borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: '1.5rem' }}>
+                        {isSubmitting && (
+                            <p role="status" aria-live="polite" style={{ color: '#a7f3d0', margin: '0 0 1rem', fontWeight: 600 }}>
+                                Confirming booking and checking availability.
+                            </p>
+                        )}
+                        <div className="booking-wizard-actions booking-review-actions">
                             <button
                                 type="button"
                                 onClick={handlePrevStep}
@@ -1105,8 +1059,9 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                                 type="button"
                                 onClick={handleSubmitBooking}
                                 disabled={isSubmitting}
-                                style={{ backgroundColor: '#10b981', color: '#fff', border: 'none', padding: '12px 32px', borderRadius: '8px', cursor: 'pointer', fontWeight: 'bold', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                                {isSubmitting ? 'Processing Payment...' : `Pay $${totalPrice.toLocaleString()} & Book`}
+                                aria-busy={isSubmitting}
+                                style={{ backgroundColor: '#10b981', color: '#fff', border: 'none', padding: '12px 32px', borderRadius: '8px', cursor: isSubmitting ? 'not-allowed' : 'pointer', opacity: isSubmitting ? 0.65 : 1, fontWeight: 'bold', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px' }}>
+                                {isSubmitting ? 'Confirming Booking...' : `Confirm ${totalPriceDisplay} booking`}
                             </button>
                         </div>
                     </div>
@@ -1131,10 +1086,11 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                             ✓
                         </div>
                         <h2 style={{ fontSize: '2rem', color: '#34d399', fontWeight: 'bold', marginBottom: '0.5rem' }}>Booking Confirmed!</h2>
-                        <p style={{ color: 'rgba(255,255,255,0.6)', marginBottom: '2rem' }}>Your payment was processed successfully. Thank you for flying with Gemini Airways!</p>
+                        <p style={{ color: 'rgba(255,255,255,0.6)', marginBottom: '0.5rem' }}>Your booking is confirmed. Payment is not collected in this demo.</p>
+                        <p style={{ color: '#34d399', marginBottom: '2rem', fontWeight: 'bold' }}>Confirmed total: {bookingResult.totalPrice}</p>
 
                         <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', alignItems: 'center', marginBottom: '2.5rem' }}>
-                            {passengers.map((p, idx) => (
+                            {bookingResult.passengers.map((p, idx) => (
                                 /* Boarding Pass Card View Overlay */
                                 <div key={idx} style={{
                                     width: '100%',
@@ -1203,7 +1159,7 @@ export default function BookingCheckoutWizard({ flight, occupiedSeats: initialOc
                             ))}
                         </div>
 
-                        <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+                        <div className="booking-success-actions">
                             <Link href="/profile" style={{ display: 'inline-block', backgroundColor: '#8b5cf6', color: '#fff', textDecoration: 'none', padding: '10px 24px', borderRadius: '8px', fontWeight: 'bold' }}>
                                 View Profile Bookings
                             </Link>

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -233,7 +233,8 @@ test.describe('Admin Control Journey', () => {
           gender: 'Other',
           seatNumber: '11A',
           cabinClass: 'ECONOMY'
-        }]
+        }],
+        idempotencyKey: '92160e58-74ee-460d-a98f-f58d1ea71477'
       })
     ]);
 

--- a/e2e/booking-authority.spec.ts
+++ b/e2e/booking-authority.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test } from '@playwright/test';
+import FlightBookingService from '../lib/FlightBookingService';
+import { prisma } from '../lib/prisma';
+
+test.describe('Authoritative booking persistence', () => {
+  const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const emails = [`authority-a-${suffix}@example.com`, `authority-b-${suffix}@example.com`];
+  const flightNumbers = [`RA${suffix.slice(-6)}`, `ID${suffix.slice(-6)}`, `MM${suffix.slice(-6)}`];
+
+  test.afterAll(async () => {
+    const users = await prisma.user.findMany({ where: { email: { in: emails } } });
+    const userIds = users.map(user => user.id);
+    const flights = await prisma.flight.findMany({
+      where: { flightNumber: { in: flightNumbers } }
+    });
+    const flightIds = flights.map(flight => flight.id);
+
+    await prisma.passenger.deleteMany({
+      where: { OR: [{ flightId: { in: flightIds } }, { booking: { userId: { in: userIds } } }] }
+    });
+    await prisma.booking.deleteMany({ where: { userId: { in: userIds } } });
+    await prisma.flight.deleteMany({ where: { id: { in: flightIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+  });
+
+  test('serializes a contested seat so exactly one customer acquires it', async () => {
+    const [firstUser, secondUser] = await Promise.all(emails.map((email, index) =>
+      prisma.user.create({
+        data: { name: `Authority ${index}`, email, password: 'not-used-in-service-test' }
+      })
+    ));
+    const flight = await prisma.flight.create({
+      data: {
+        flightNumber: flightNumbers[0],
+        airline: 'Concurrency Air',
+        from: 'Seattle, USA',
+        to: 'Detroit, USA',
+        departureDate: new Date(Date.now() + 86_400_000),
+        price: '$123.45',
+        firstClassRows: 0,
+        businessRows: 0,
+        premiumEconomyRows: 0,
+        economyRows: 2,
+        seatPattern: 'AB-CD'
+      }
+    });
+    const service = new FlightBookingService();
+    const passenger = {
+      firstName: 'Race', lastName: 'Traveler', dateOfBirth: '1990-01-01',
+      passportNumber: 'RACE123', gender: 'Other', seatNumber: '1A',
+      cabinClass: 'ECONOMY'
+    };
+
+    const results = await Promise.allSettled([
+      service.bookFlight({
+        flightId: flight.id,
+        userId: firstUser.id,
+        passengers: [passenger],
+        idempotencyKey: '770b1f71-d1b3-43ed-886e-4c0ec45c4e8a'
+      }),
+      service.bookFlight({
+        flightId: flight.id,
+        userId: secondUser.id,
+        passengers: [{ ...passenger, passportNumber: 'RACE456' }],
+        idempotencyKey: '62a0767b-2913-4077-88e8-0f9391f13552'
+      })
+    ]);
+
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    expect(results.filter(result => result.status === 'rejected')).toHaveLength(1);
+    expect(await prisma.passenger.count({ where: { flightId: flight.id, seatNumber: '1A' } })).toBe(1);
+    const persisted = await prisma.booking.findMany({ where: { flightId: flight.id } });
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({ totalPrice: '$123.45', paymentIntentId: null });
+  });
+
+  test('returns one booking when the same idempotency key is repeated', async () => {
+    const user = await prisma.user.findUniqueOrThrow({ where: { email: emails[0] } });
+    const flight = await prisma.flight.create({
+      data: {
+        flightNumber: flightNumbers[1],
+        airline: 'Idempotent Air',
+        from: 'Detroit, USA',
+        to: 'Seattle, USA',
+        departureDate: new Date(Date.now() + 172_800_000),
+        price: '$200',
+        firstClassRows: 0,
+        businessRows: 1,
+        premiumEconomyRows: 0,
+        economyRows: 1,
+        seatPattern: 'AB-CD'
+      }
+    });
+    const request = {
+      flightId: flight.id,
+      userId: user.id,
+      passengers: [{
+        firstName: 'Repeat', lastName: 'Traveler', dateOfBirth: '1990-01-01',
+        passportNumber: 'REPEAT123', gender: 'Other', seatNumber: '1A',
+        cabinClass: 'BUSINESS'
+      }],
+      idempotencyKey: 'd9a8ce21-1b61-4e30-8670-cc6ab48534b9'
+    };
+    const service = new FlightBookingService();
+
+    const first = await service.bookFlight(request);
+    const retry = await service.bookFlight(request);
+
+    expect(retry.id).toBe(first.id);
+    expect(first).toMatchObject({ totalPrice: '$400', paymentIntentId: null, wasCreated: true });
+    expect(retry).toMatchObject({ totalPrice: '$400', paymentIntentId: null, wasCreated: false });
+    expect(await prisma.booking.count({
+      where: { userId: user.id, idempotencyKey: request.idempotencyKey }
+    })).toBe(1);
+
+    await expect(service.bookFlight({
+      ...request,
+      passengers: [{ ...request.passengers[0], seatNumber: '1B' }]
+    })).rejects.toThrow('Booking request ID was already used for a different booking.');
+
+    const otherFlight = await prisma.flight.create({
+      data: {
+        flightNumber: flightNumbers[2],
+        airline: 'Mismatch Air',
+        from: 'Seattle, USA',
+        to: 'Chicago, USA',
+        departureDate: new Date(Date.now() + 259_200_000),
+        price: '$250',
+        firstClassRows: 0,
+        businessRows: 1,
+        premiumEconomyRows: 0,
+        economyRows: 1,
+        seatPattern: 'AB-CD'
+      }
+    });
+    await expect(service.bookFlight({ ...request, flightId: otherFlight.id }))
+      .rejects.toThrow('Booking request ID was already used for a different booking.');
+  });
+});

--- a/e2e/booking.spec.ts
+++ b/e2e/booking.spec.ts
@@ -43,7 +43,7 @@ test.describe('Flight Booking Journey', () => {
     }
   });
 
-  test('User can search, select cabin/seat, complete payment wizard, and view ticket on profile', async ({ page }) => {
+  test('User can search, select cabin and seat, confirm booking, and view it on profile', async ({ page }) => {
     // Find an upcoming flight instance from the seeded database to make search reliable
     const targetFlight = await prisma.flight.findFirst({
       where: {
@@ -89,9 +89,11 @@ test.describe('Flight Booking Journey', () => {
 
     // Expect to be redirected to the booking checkout page
     await expect(page).toHaveURL(new RegExp(`/book/${targetFlight.id}`));
+    await page.setViewportSize({ width: 320, height: 800 });
 
     // --- STEP 1: Traveler Information ---
     await expect(page.locator('h2:has-text("Traveler Information")')).toBeVisible();
+    await expect(page.locator('.booking-traveler-actions')).toHaveCSS('flex-direction', 'column');
     
     // Fill in Passenger #1 details
     await page.fill('input[placeholder="John"]', 'Bob');
@@ -104,35 +106,50 @@ test.describe('Flight Booking Journey', () => {
 
     // --- STEP 2: Seat Selection ---
     await expect(page.locator('h2:has-text("Select Your Seats")')).toBeVisible();
+    await expect(page.locator('.booking-seat-actions')).toHaveCSS('flex-direction', 'column');
     
     // Select seat 11A (an economy seat)
     const seatButton = page.locator('button[title="Select Seat 11A"]');
     await expect(seatButton).toBeVisible();
     await seatButton.click();
     
-    // Click Billing & Summary
-    await page.click('button:has-text("Billing & Summary →")');
+    // Continue to review
+    await page.click('button:has-text("Review Booking →")');
 
-    // --- STEP 3: Payment ---
-    await expect(page.locator('h2:has-text("Review & Purchase")')).toBeVisible();
+    // --- STEP 3: Review ---
+    await expect(page.locator('h2:has-text("Review Booking")')).toBeVisible();
     
     // Verify booking summary details
     await expect(page.locator('text=Bob Jones').first()).toBeVisible();
     await expect(page.locator('text=Class: ECONOMY | Seat: 11A').first()).toBeVisible();
 
-    // Fill simulated payment card information
-    await page.fill('input[placeholder="4111 2222 3333 4444"]', '4111222233334444');
-    await page.fill('input[placeholder="JOHN DOE"]', 'BOB JONES');
-    await page.fill('input[placeholder="MM/YY"]', '12/29');
-    await page.fill('input[placeholder="123"]', '123');
+    await expect(page.locator('text=Payment is not collected in this demo')).toBeVisible();
+    await expect(page.locator('input[placeholder="4111 2222 3333 4444"]')).not.toBeVisible();
 
-    // Submit Booking
-    await page.click('button:has-text("Pay ")');
+    const reviewActions = page.locator('.booking-review-actions');
+    await expect(reviewActions).toHaveCSS('flex-direction', 'column');
+    const confirmButton = page.locator('button:has-text("Confirm $")');
+    const actionsBox = await reviewActions.boundingBox();
+    const confirmBox = await confirmButton.boundingBox();
+    expect(actionsBox).not.toBeNull();
+    expect(confirmBox).not.toBeNull();
+    expect(confirmBox!.width).toBeLessThanOrEqual(actionsBox!.width);
+
+    // Confirm Booking
+    await confirmButton.click();
 
     // --- STEP 4: Success & Boarding Pass ---
     await expect(page.locator('h2:has-text("Booking Confirmed!")')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.booking-success-actions')).toHaveCSS('flex-direction', 'column');
     await expect(page.locator('text=Bob Jones').first()).toBeVisible();
     await expect(page.locator('text=11A').first()).toBeVisible();
+    const persistedBooking = await prisma.booking.findFirstOrThrow({
+      where: { user: { email: uniqueEmail } },
+      orderBy: { createdAt: 'desc' }
+    });
+    expect(persistedBooking.totalPrice).toBe(targetFlight.price);
+    expect(persistedBooking.paymentIntentId).toBeNull();
+    expect(persistedBooking.idempotencyKey).toMatch(/^[0-9a-f-]{36}$/i);
     
     // Navigate to profile bookings
     await page.click('a:has-text("View Profile Bookings")');

--- a/e2e/multi-passenger.spec.ts
+++ b/e2e/multi-passenger.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma } from '../lib/prisma';
+import { calculateBookingTotal } from '../lib/bookingPricing';
 
 test.describe('Multi-Passenger Booking Journey', () => {
   const uniqueEmail = `multibook-${Date.now()}@example.com`;
@@ -119,23 +120,17 @@ test.describe('Multi-Passenger Booking Journey', () => {
     await expect(page.locator('text=Seat: 11B')).toBeVisible();
 
     // Let's go to step 3
-    await page.click('button:has-text("Billing & Summary →")');
+    await page.click('button:has-text("Review Booking →")');
 
-    // --- STEP 3: Billing & Review ---
-    await expect(page.locator('h2:has-text("Review & Purchase")')).toBeVisible();
+    // --- STEP 3: Review ---
+    await expect(page.locator('h2:has-text("Review Booking")')).toBeVisible();
     await expect(page.locator('text=Alice Smith')).toBeVisible();
     await expect(page.locator('text=Class: ECONOMY | Seat: 11A')).toBeVisible();
     await expect(page.locator('text=Bob Jones')).toBeVisible();
     await expect(page.locator('text=Class: ECONOMY | Seat: 11B')).toBeVisible();
 
-    // Fill card info
-    await page.fill('input[placeholder="4111 2222 3333 4444"]', '4111222233334444');
-    await page.fill('input[placeholder="JOHN DOE"]', 'ALICE SMITH');
-    await page.fill('input[placeholder="MM/YY"]', '12/29');
-    await page.fill('input[placeholder="123"]', '123');
-
-    // Pay
-    await page.click('button:has-text("Pay ")');
+    // Confirm
+    await page.click('button:has-text("Confirm $")');
 
     // --- STEP 4: Confirmation & Boarding Passes ---
     await expect(page.locator('h2:has-text("Booking Confirmed!")')).toBeVisible({ timeout: 12000 });
@@ -145,5 +140,14 @@ test.describe('Multi-Passenger Booking Journey', () => {
     await expect(page.locator('text=11A').first()).toBeVisible();
     await expect(page.locator('text=Bob Jones').first()).toBeVisible();
     await expect(page.locator('text=11B').first()).toBeVisible();
+    const persistedBooking = await prisma.booking.findFirstOrThrow({
+      where: { user: { email: uniqueEmail } },
+      orderBy: { createdAt: 'desc' }
+    });
+    expect(persistedBooking.totalPrice).toBe(calculateBookingTotal(targetFlight.price, [
+      { cabinClass: 'ECONOMY' },
+      { cabinClass: 'ECONOMY' }
+    ]).formatted);
+    expect(persistedBooking.paymentIntentId).toBeNull();
   });
 });

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -96,15 +96,11 @@ test.describe('User Notifications & Alerts Journey', () => {
     const seatBtn = page.locator('button[title="Select Seat 11A"]');
     await expect(seatBtn).toBeVisible();
     await seatBtn.click();
-    await page.click('button:has-text("Billing & Summary →")');
+    await page.click('button:has-text("Review Booking →")');
 
-    // Purchase
-    await expect(page.locator('h2:has-text("Review & Purchase")')).toBeVisible();
-    await page.fill('input[placeholder="4111 2222 3333 4444"]', '4111222233334444');
-    await page.fill('input[placeholder="JOHN DOE"]', 'BOB JONES');
-    await page.fill('input[placeholder="MM/YY"]', '12/29');
-    await page.fill('input[placeholder="123"]', '123');
-    await page.click('button:has-text("Pay ")');
+    // Confirm booking
+    await expect(page.locator('h2:has-text("Review Booking")')).toBeVisible();
+    await page.click('button:has-text("Confirm $")');
 
     // Expect confirmation
     await expect(page.locator('h2:has-text("Booking Confirmed!")')).toBeVisible({ timeout: 12000 });

--- a/lib/FlightBookingService.ts
+++ b/lib/FlightBookingService.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { assertSeatAvailableForCabin } from '@/lib/seatLayout';
 import { lockFlightForUpdate } from '@/lib/flightLock';
 import { flightBookingServiceSchema, parseInput } from '@/lib/validation';
+import { calculateBookingTotal } from '@/lib/bookingPricing';
 
 export interface PassengerInput {
   firstName: string;
@@ -13,15 +14,43 @@ export interface PassengerInput {
   cabinClass: string;
 }
 
+function passengerRequestSignature(passenger: PassengerInput): string {
+    const dateOfBirth = passenger.dateOfBirth instanceof Date
+        ? passenger.dateOfBirth.toISOString().slice(0, 10)
+        : passenger.dateOfBirth.slice(0, 10);
+    return JSON.stringify([
+        passenger.firstName,
+        passenger.lastName,
+        dateOfBirth,
+        passenger.passportNumber,
+        passenger.gender,
+        passenger.seatNumber,
+        passenger.cabinClass
+    ]);
+}
+
+function matchesPersistedRequest(
+    existingFlightId: number | null,
+    existingPassengers: PassengerInput[],
+    flightId: number,
+    passengers: PassengerInput[]
+): boolean {
+    if (existingFlightId !== flightId || existingPassengers.length !== passengers.length) {
+        return false;
+    }
+    const existingSignatures = existingPassengers.map(passengerRequestSignature).sort();
+    const requestedSignatures = passengers.map(passengerRequestSignature).sort();
+    return existingSignatures.every((signature, index) => signature === requestedSignatures[index]);
+}
+
 export default class FlightBookingService {
     async bookFlight(bookingData: { 
-        flightId?: number; 
-        userId?: string; 
-        totalPrice?: string; 
+        flightId: number;
+        userId: string;
         passengers: PassengerInput[];
-        paymentIntentId?: string; 
+        idempotencyKey: string;
     }) {
-        const { flightId, userId, totalPrice, passengers, paymentIntentId } = parseInput(
+        const { flightId, userId, passengers, idempotencyKey } = parseInput(
             flightBookingServiceSchema,
             bookingData
         );
@@ -31,6 +60,26 @@ export default class FlightBookingService {
             await lockFlightForUpdate(tx, flightId);
             const flight = await tx.flight.findUnique({ where: { id: flightId } });
             if (!flight) throw new Error("Flight not found");
+
+            const existingRequest = await tx.booking.findFirst({
+                where: { userId, idempotencyKey },
+                include: { passengers: true }
+            });
+            if (existingRequest) {
+                if (!matchesPersistedRequest(
+                    existingRequest.flightId,
+                    existingRequest.passengers,
+                    flightId,
+                    passengers
+                )) {
+                    throw new Error('Booking request ID was already used for a different booking.');
+                }
+                return { ...existingRequest, wasCreated: false };
+            }
+
+            if (flight.status === 'CANCELLED' || flight.departureDate.getTime() <= Date.now()) {
+                throw new Error('Flight is not available for booking.');
+            }
 
             // Check if any seat is already booked on this flight
             const requestedSeats = passengers.map(p => p.seatNumber);
@@ -63,13 +112,21 @@ export default class FlightBookingService {
                 }
             }
 
+            const total = calculateBookingTotal(
+                flight.price,
+                passengers.map(passenger => ({
+                    cabinClass: passenger.cabinClass as 'ECONOMY' | 'PREMIUM_ECONOMY' | 'BUSINESS' | 'FIRST'
+                }))
+            );
+
             // Create booking with nested passengers
-            return await tx.booking.create({
+            const booking = await tx.booking.create({
                 data: {
                     flightId,
                     userId,
-                    totalPrice: totalPrice || "$0",
-                    paymentIntentId: paymentIntentId || `mock_tx_${Date.now()}`,
+                    totalPrice: total.formatted,
+                    paymentIntentId: null,
+                    idempotencyKey,
                     passengers: {
                         create: passengers.map(p => ({
                             firstName: p.firstName,
@@ -87,6 +144,7 @@ export default class FlightBookingService {
                     passengers: true
                 }
             });
+            return { ...booking, wasCreated: true };
         });
 
         return savedBooking;

--- a/lib/PointsActivityService.ts
+++ b/lib/PointsActivityService.ts
@@ -1,6 +1,7 @@
 import { PointsActivityData, StartingPoints } from "./data/PointsActivityData";
 import { PointsActivityDisplayData } from "./types/PointsActivity";
 import { Booking, Flight } from "@prisma/client";
+import { parsePriceToCents } from "./bookingPricing";
 
 type BookingWithFlight = Booking & { flight: Flight | null };
 
@@ -15,7 +16,11 @@ class PointsActivityService {
 
   private parsePrice(priceStr: string | null | undefined): number {
     if (!priceStr) return 0;
-    return parseInt(priceStr.replace(/[^0-9]/g, ""), 10) || 0;
+    try {
+      return Math.floor(parsePriceToCents(priceStr) / 100);
+    } catch {
+      return 0;
+    }
   }
 
   getCurrentPoints(): number {

--- a/lib/bookingPricing.ts
+++ b/lib/bookingPricing.ts
@@ -1,0 +1,48 @@
+export const CABIN_FARE_PERCENT = {
+    ECONOMY: 100,
+    PREMIUM_ECONOMY: 150,
+    BUSINESS: 200,
+    FIRST: 300
+} as const;
+
+export type CabinClass = keyof typeof CABIN_FARE_PERCENT;
+
+export function parsePriceToCents(price: string): number {
+    const normalized = price.trim();
+    if (!/^\$?(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d{1,2})?$/.test(normalized)) {
+        throw new Error('Flight price is invalid.');
+    }
+
+    const numeric = normalized.replace(/[$,]/g, '');
+    const [whole, fraction = ''] = numeric.split('.');
+    const cents = Number(whole) * 100 + Number(fraction.padEnd(2, '0'));
+    if (!Number.isSafeInteger(cents) || cents < 0) {
+        throw new Error('Flight price is invalid.');
+    }
+    return cents;
+}
+
+export function calculatePassengerFareCents(basePriceCents: number, cabinClass: CabinClass): number {
+    return Math.round(basePriceCents * CABIN_FARE_PERCENT[cabinClass] / 100);
+}
+
+export function formatPrice(cents: number): string {
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: cents % 100 === 0 ? 0 : 2,
+        maximumFractionDigits: cents % 100 === 0 ? 0 : 2
+    }).format(cents / 100);
+}
+
+export function calculateBookingTotal(
+    basePrice: string,
+    passengers: Array<{ cabinClass: CabinClass }>
+): { cents: number; formatted: string } {
+    const basePriceCents = parsePriceToCents(basePrice);
+    const cents = passengers.reduce(
+        (sum, passenger) => sum + calculatePassengerFareCents(basePriceCents, passenger.cabinClass),
+        0
+    );
+    return { cents, formatted: formatPrice(cents) };
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -172,11 +172,10 @@ export const passengerSchema = z.object({
 
 export const bookingRequestSchema = z.object({
     flightId: positiveId('Flight ID'),
-    totalPrice: z.string().trim().max(32).optional(),
     passengers: z.array(passengerSchema, { error: 'At least one passenger is required.' })
         .min(1, 'At least one passenger is required.')
         .max(MAX_PASSENGERS_PER_BOOKING),
-    paymentIntentId: z.string().trim().min(1).max(255).optional()
+    idempotencyKey: z.uuid('Booking request ID must be a UUID.')
 }).strict();
 
 export const flightBookingServiceSchema = bookingRequestSchema.extend({

--- a/prisma/migrations/20260713020000_authoritative_booking/migration.sql
+++ b/prisma/migrations/20260713020000_authoritative_booking/migration.sql
@@ -1,0 +1,6 @@
+-- Existing demo bookings predate idempotency keys, so the column remains
+-- nullable while all new booking requests require one at the service boundary.
+ALTER TABLE "Booking" ADD COLUMN "idempotencyKey" TEXT;
+
+CREATE UNIQUE INDEX "Booking_userId_idempotencyKey_key"
+ON "Booking"("userId", "idempotencyKey");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,12 +79,14 @@ model CityGuide {
   favorites UserFavorite[]
   reviews   Review[]
 }
+
 model Booking {
-  id              Int         @id @default(autoincrement())
-  createdAt       DateTime    @default(now())
-  status          String      @default("CONFIRMED")
+  id              Int      @id @default(autoincrement())
+  createdAt       DateTime @default(now())
+  status          String   @default("CONFIRMED")
   paymentIntentId String?
-  totalPrice      String      @default("")
+  totalPrice      String   @default("")
+  idempotencyKey  String?
 
   flightId Int?
   flight   Flight? @relation(fields: [flightId], references: [id])
@@ -93,6 +95,8 @@ model Booking {
   user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   passengers Passenger[]
+
+  @@unique([userId, idempotencyKey])
 }
 
 model Passenger {
@@ -108,12 +112,11 @@ model Passenger {
   bookingId Int
   booking   Booking @relation(fields: [bookingId], references: [id], onDelete: Cascade)
 
-  flightId  Int
-  flight    Flight  @relation(fields: [flightId], references: [id], onDelete: Cascade)
+  flightId Int
+  flight   Flight @relation(fields: [flightId], references: [id], onDelete: Cascade)
 
   @@unique([flightId, seatNumber])
 }
-
 
 model Flight {
   id            Int       @id @default(autoincrement())
@@ -132,7 +135,7 @@ model Flight {
   economyRows        Int?
   seatPattern        String?
 
-  bookings Booking[]
+  bookings   Booking[]
   passengers Passenger[]
 
   @@unique([flightNumber, departureDate])
@@ -163,7 +166,7 @@ model Review {
 }
 
 model FlightSchedule {
-  id            Int      @id @default(autoincrement())
+  id            Int     @id @default(autoincrement())
   flightNumber  String
   airline       String
   from          String
@@ -172,7 +175,7 @@ model FlightSchedule {
   returnTime    String?
   daysOfWeek    Int[]
   price         String
-  isActive      Boolean  @default(true)
+  isActive      Boolean @default(true)
 
   firstClassRows     Int?
   businessRows       Int?
@@ -187,7 +190,7 @@ model Notification {
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   title     String
   message   String
-  type      String   // "FLIGHT_STATUS" | "POINTS" | "SYSTEM"
+  type      String // "FLIGHT_STATUS" | "POINTS" | "SYSTEM"
   isRead    Boolean  @default(false)
   createdAt DateTime @default(now())
 


### PR DESCRIPTION
## Summary
Make server-side fare calculation, seat inventory, and idempotency authoritative so browser-submitted pricing or payment identifiers cannot alter persisted bookings.

## Changes
- calculate fares from locked flight data using integer cents
- serialize seat acquisition and reject unavailable, cancelled, or departed inventory
- bind idempotency keys to normalized booking requests and reject mismatched reuse
- remove fake card collection and payment identifiers from checkout
- render confirmed totals and passenger details from the server response
- add the Prisma idempotency migration and mark roadmap P0.4 complete

## Testing
- [x] Unit tests added/updated: 29 suites, 230 tests
- [x] Manual testing steps: full 320x800 booking journey through confirmation
- [x] TypeScript, ESLint, production build, Prisma validation/migration status
- [x] Playwright: 10/10 journeys against PostgreSQL
- [x] Docker build, non-root smoke test, and 17-layer secret scan

## Screenshots (if applicable)
Not included; responsive behavior is covered by the complete 320x800 Playwright journey.

## Related Issues
Roadmap P0.4