### PR TITLE
feat(auth): add identity abuse protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/travel_app
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=
+# Direct local development does not trust forwarded addresses. The bundled
+# Docker proxy supplies its own production-safe value to the app container.
+AUTH_TRUSTED_PROXY_HOPS=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/travel_app
       NEXTAUTH_SECRET: ci-only-nextauth-secret-at-least-32-characters
       NEXTAUTH_URL: http://localhost:3000
+      AUTH_TRUSTED_PROXY_HOPS: 1
     steps:
       - uses: actions/checkout@v4
 
@@ -57,6 +58,10 @@ jobs:
 
       - name: Run Playwright E2E tests
         run: npx playwright test
+        env:
+          # Playwright connects directly to the local dev server, not through a
+          # trusted ingress. Ignore forwarded-address headers for this step.
+          AUTH_TRUSTED_PROXY_HOPS: 0
 
       - name: Build and inspect production container
         run: |

--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ cp .env.example .env
 ```
 
 Replace `NEXTAUTH_SECRET` with a securely generated value of at least 32
-characters. Deployed environments must inject all configuration at runtime;
-never bake `.env` into an image. See [SECURITY.md](SECURITY.md) for rotation and
-incident guidance.
+characters. Local non-container development may leave
+`AUTH_TRUSTED_PROXY_HOPS` at `0`. The recommended Compose deployment supplies
+its own safe value; other deployments must set it to the exact number of
+trusted right-most proxy entries. Deployed environments must inject all secret
+configuration at runtime; never bake `.env` into an image. See
+[SECURITY.md](SECURITY.md) for rotation and incident guidance.
 
 ### Using Docker (Recommended)
 
@@ -21,7 +24,11 @@ To quickly get the application running with a database and demo data, use Docker
 docker compose up --build
 ```
 
-This will automatically start the database, run migrations, seed data, and serve the app at [http://localhost:3000](http://localhost:3000).
+This automatically starts the database, runs migrations, seeds data, and serves
+the app at [http://localhost:3000](http://localhost:3000). Compose exposes the
+app only through a bundled reverse proxy. The proxy replaces any incoming
+`X-Forwarded-For` value with the connecting address before forwarding the
+request, so clients cannot choose the identity used by authentication limits.
 
 ### Manual Setup
 

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -116,8 +116,8 @@ Acceptance criteria:
 
 ### P0.5 Harden identity and personal data
 
-- [ ] Normalize email addresses and prevent case-variant duplicate accounts.
-- [ ] Add registration and authentication rate limits.
+- [x] Normalize email addresses and prevent case-variant duplicate accounts.
+- [x] Add registration and authentication rate limits.
 - [ ] Add email verification, password reset, and recovery flows.
 - [ ] Use generic account-existence responses where appropriate.
 - [ ] Define encryption, access, retention, redaction, and deletion rules for
@@ -502,6 +502,7 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-12 | P1.4 | In progress | #32 | Added a concurrency-safe manual occurrence generator with custom seating; scheduled background generation and horizon monitoring remain. |
 | 2026-07-12 | P0.3 | Complete | #37 | Added shared Zod schemas, normalized mutation inputs, structured safe errors, and request/mutation limits. |
 | 2026-07-12 | P0.4 | Complete | #38 | Made server fares and inventory authoritative, removed fake payment identifiers, and added idempotent, concurrency-tested booking persistence. |
+| 2026-07-12 | P0.5 | In progress | Pending | Canonicalized email identity, added database-backed registration and login throttles, and made immediate registration responses generic; verified activation remains. |
 
 ## Recommended first delivery sequence
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,12 +10,26 @@
   runtime environment in deployed environments.
 - Generate `NEXTAUTH_SECRET` with a cryptographically secure generator and use
   at least 32 characters.
+- Local development may use `AUTH_TRUSTED_PROXY_HOPS=0`. Production requires a
+  value from 1 through 5 and a trusted ingress that sanitizes
+  `X-Forwarded-For`. Set it to the exact number of trusted right-most proxy
+  entries. Requests with incomplete chains fail closed.
+- The recommended Compose deployment exposes only its bundled proxy. That
+  proxy replaces client-provided `X-Forwarded-For` content with the connecting
+  address, and the app trusts exactly that one proxy hop. For other deployment
+  topologies, every trusted ingress must overwrite or safely append the header
+  according to the configured hop count; the app must not be directly
+  reachable around those ingresses.
 - Store deployment secrets in the hosting platform's secret manager and limit
   access to the people and workloads that require them.
 
 The application validates required server settings during Node.js startup. A
 missing or malformed setting prevents startup instead of allowing a partially
 configured deployment.
+
+Authentication throttles store only keyed digests of email/IP identifiers.
+Every throttle operation deletes a bounded batch of expired rows so attacker-
+controlled identifiers are not retained indefinitely.
 
 ## Responding to an image that contains secrets
 

--- a/__tests__/app/api/register.test.ts
+++ b/__tests__/app/api/register.test.ts
@@ -1,26 +1,74 @@
 /** @jest-environment node */
 import { POST } from '@/app/api/auth/register/route';
 import { prisma } from '@/lib/prisma';
+import { consumeAuthRateLimit } from '@/lib/authRateLimit';
 
 jest.mock('@/lib/prisma', () => ({
     prisma: { user: { findUnique: jest.fn(), create: jest.fn() } },
 }));
 jest.mock('bcryptjs', () => ({ hash: jest.fn().mockResolvedValue('hashed-pw') }));
+jest.mock('@/lib/authRateLimit', () => ({ consumeAuthRateLimit: jest.fn() }));
 
 const mockedPrisma = prisma as unknown as {
     user: { findUnique: jest.Mock; create: jest.Mock };
 };
+const mockedConsumeRateLimit = consumeAuthRateLimit as jest.Mock;
 
-const makeReq = (body: unknown) => new Request('http://localhost/api/auth/register', {
+const makeReq = (body: unknown, headers: Record<string, string> = {}) => new Request('http://localhost/api/auth/register', {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...headers },
     body: JSON.stringify(body)
 });
 
 describe('POST /api/auth/register', () => {
-    beforeEach(() => jest.clearAllMocks());
+    beforeEach(() => {
+        jest.clearAllMocks();
+        delete process.env.AUTH_TRUSTED_PROXY_HOPS;
+        mockedConsumeRateLimit.mockResolvedValue({ allowed: true, retryAfterSeconds: 0 });
+    });
 
-    it('never returns the password hash on success', async () => {
+    it('does not create a global address bucket when proxy trust is not configured', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue({ id: 'existing' });
+
+        await POST(makeReq(
+            { name: 'Ada', email: 'ada@example.com', password: 'password123' },
+            { 'x-forwarded-for': '198.51.100.10' }
+        ));
+
+        expect(mockedConsumeRateLimit).not.toHaveBeenCalledWith(
+            'register-address', expect.anything(), expect.anything()
+        );
+    });
+
+    it('fails closed when a configured trusted ingress does not provide a complete chain', async () => {
+        process.env.AUTH_TRUSTED_PROXY_HOPS = '2';
+
+        const res = await POST(makeReq(
+            { name: 'Ada', email: 'ada@example.com', password: 'password123' },
+            { 'x-forwarded-for': '203.0.113.9' }
+        ));
+
+        expect(res.status).toBe(400);
+        expect(mockedConsumeRateLimit).not.toHaveBeenCalled();
+        expect(mockedPrisma.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('uses the right-side address supplied by the configured trusted ingress', async () => {
+        process.env.AUTH_TRUSTED_PROXY_HOPS = '1';
+        mockedPrisma.user.findUnique.mockResolvedValue({ id: 'existing' });
+
+        await POST(makeReq(
+            { name: 'Ada', email: 'ada@example.com', password: 'password123' },
+            { 'x-forwarded-for': 'spoofed-by-client, 203.0.113.9' }
+        ));
+
+        expect(mockedConsumeRateLimit).toHaveBeenNthCalledWith(2, 'register-address', '203.0.113.9', {
+            limit: 50,
+            windowSeconds: 60 * 60,
+        });
+    });
+
+    it('returns only a generic acceptance response on success', async () => {
         mockedPrisma.user.findUnique.mockResolvedValue(null);
         mockedPrisma.user.create.mockResolvedValue({
             id: 'u1',
@@ -31,12 +79,11 @@ describe('POST /api/auth/register', () => {
         });
 
         const res = await POST(makeReq({ name: 'Ada', email: 'ada@example.com', password: 'password123' }));
-        expect(res.status).toBe(201);
+        expect(res.status).toBe(202);
 
         const data = await res.json();
-        expect(data.user).toBeDefined();
-        expect(data.user.password).toBeUndefined();
-        expect(data.user).toMatchObject({ id: 'u1', email: 'ada@example.com' });
+        expect(data.user).toBeUndefined();
+        expect(data).toEqual({ message: 'If this address can be registered, the request has been accepted.' });
     });
 
     it('rejects an invalid email', async () => {
@@ -111,12 +158,53 @@ describe('POST /api/auth/register', () => {
         expect(mockedPrisma.user.create).not.toHaveBeenCalled();
     });
 
-    it('rejects a duplicate user', async () => {
+    it('uses the same response for an existing account to prevent enumeration', async () => {
         mockedPrisma.user.findUnique.mockResolvedValue({ id: 'existing' });
         const res = await POST(makeReq({ name: 'Ada', email: 'ada@example.com', password: 'password123' }));
-        expect(res.status).toBe(409);
-        expect(await res.json()).toMatchObject({ error: { code: 'ACCOUNT_EXISTS' } });
+        expect(res.status).toBe(202);
+        expect(await res.json()).toEqual({
+            message: 'If this address can be registered, the request has been accepted.'
+        });
         expect(mockedPrisma.user.create).not.toHaveBeenCalled();
+    });
+
+    it('rate limits registration by normalized email and client address', async () => {
+        process.env.AUTH_TRUSTED_PROXY_HOPS = '1';
+        mockedConsumeRateLimit
+            .mockResolvedValueOnce({ allowed: true, retryAfterSeconds: 0 })
+            .mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 120 });
+
+        const res = await POST(makeReq(
+            { name: 'Ada', email: ' ADA@Example.COM ', password: 'password123' },
+            { 'x-forwarded-for': '203.0.113.9' }
+        ));
+
+        expect(res.status).toBe(429);
+        expect(res.headers.get('retry-after')).toBe('120');
+        expect(await res.json()).toEqual({
+            error: {
+                code: 'RATE_LIMITED',
+                message: 'Too many account requests. Please try again later.',
+                fields: {}
+            }
+        });
+        expect(mockedConsumeRateLimit).toHaveBeenNthCalledWith(1, 'register-email', 'ada@example.com', {
+            limit: 3,
+            windowSeconds: 60 * 60,
+        });
+        expect(mockedPrisma.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('treats a concurrent normalized-email conflict as the generic accepted response', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue(null);
+        mockedPrisma.user.create.mockRejectedValue({ code: 'P2002' });
+
+        const res = await POST(makeReq({ name: 'Ada', email: 'ada@example.com', password: 'password123' }));
+
+        expect(res.status).toBe(202);
+        expect(await res.json()).toEqual({
+            message: 'If this address can be registered, the request has been accepted.'
+        });
     });
 
     it('returns 500 when an internal database error occurs', async () => {

--- a/__tests__/components/UserAuthForm.test.tsx
+++ b/__tests__/components/UserAuthForm.test.tsx
@@ -2,16 +2,35 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import UserAuthForm from '@/app/login/components/user-auth-form';
+import { signIn } from 'next-auth/react';
 
 jest.mock('next-auth/react', () => ({ signIn: jest.fn() }));
 jest.mock('next/navigation', () => ({
     useRouter: () => ({ push: jest.fn(), refresh: jest.fn() })
 }));
 
+const contrastRatio = (foreground: string, background: string) => {
+    const luminance = (hex: string) => {
+        const channels = hex.match(/[a-f\d]{2}/gi)!.map(channel => parseInt(channel, 16) / 255);
+        const [red, green, blue] = channels.map(channel =>
+            channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+        );
+        return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+    };
+    const values = [luminance(foreground), luminance(background)].sort((a, b) => b - a);
+    return (values[0] + 0.05) / (values[1] + 0.05);
+};
+
 describe('UserAuthForm registration errors', () => {
     beforeEach(() => {
         jest.restoreAllMocks();
+        jest.clearAllMocks();
         global.fetch = jest.fn();
+    });
+
+    it('keeps accepted and pending status text above WCAG AA contrast', () => {
+        expect(contrastRatio('#86efac', '#0d0c14')).toBeGreaterThanOrEqual(4.5);
+        expect(contrastRatio('#d4d4d8', '#0d0c14')).toBeGreaterThanOrEqual(4.5);
     });
 
     it('shows structured server validation errors and associates them with fields', async () => {
@@ -32,13 +51,87 @@ describe('UserAuthForm registration errors', () => {
         fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
         fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
 
-        expect(await screen.findByRole('alert')).toHaveTextContent('Enter a valid email address.');
+        const alert = await screen.findByRole('alert');
+        expect(alert).toHaveTextContent('Enter a valid email address.');
         await waitFor(() => {
             expect(screen.getByLabelText('Email')).toHaveAttribute('aria-invalid', 'true');
             expect(screen.getByLabelText('Email')).toHaveAttribute(
                 'aria-describedby',
                 'registration-email-error'
             );
+            expect(screen.getByLabelText('Email')).toHaveFocus();
         });
+    });
+
+    it('shows a generic login failure without exposing account existence', async () => {
+        (signIn as jest.Mock).mockResolvedValue({ error: 'CredentialsSignin' });
+        render(<UserAuthForm type="login" />);
+
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'unknown@example.com' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrong-password' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Sign In with Email' }));
+
+        const alert = await screen.findByRole('alert');
+        expect(alert).toHaveTextContent('Invalid email or password.');
+        await waitFor(() => expect(alert).toHaveFocus());
+    });
+
+    it('shows the same neutral state after every accepted registration without signing in', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                message: 'If this address can be registered, the request has been accepted.'
+            })
+        } as Response);
+        render(<UserAuthForm type="signup" />);
+
+        fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Ada' } });
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'ada@example.com' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrong-password' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+        expect(await screen.findByRole('status')).toHaveTextContent(
+            'If this address is eligible, you can now sign in with your credentials.'
+        );
+        expect(screen.getByRole('status')).toHaveStyle({ color: '#86efac' });
+        expect(screen.getByLabelText('Password')).toHaveAttribute('autocomplete', 'new-password');
+        expect(signIn).not.toHaveBeenCalled();
+    });
+
+    it('recovers from a rejected login request with a focusable generic error', async () => {
+        (signIn as jest.Mock).mockRejectedValue(new Error('network unavailable'));
+        render(<UserAuthForm type="login" />);
+
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'ada@example.com' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Sign In with Email' }));
+
+        const alert = await screen.findByRole('alert');
+        expect(alert).toHaveTextContent('Unable to sign in right now. Please try again.');
+        expect(alert).toHaveStyle({ outline: '2px solid #f87171', outlineOffset: '2px' });
+        expect(screen.getByLabelText('Password')).toHaveAttribute('autocomplete', 'current-password');
+        expect(screen.getByRole('button', { name: 'Sign In with Email' })).toBeEnabled();
+        await waitFor(() => expect(alert).toHaveFocus());
+    });
+
+    it('announces and visibly disables the pending login state', async () => {
+        let resolveSignIn!: (value: { error: string }) => void;
+        (signIn as jest.Mock).mockImplementation(() => new Promise(resolve => {
+            resolveSignIn = resolve;
+        }));
+        render(<UserAuthForm type="login" />);
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'ada@example.com' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Sign In with Email' }));
+
+        const pendingButton = screen.getByRole('button', { name: 'Signing in…' });
+        expect(pendingButton).toBeDisabled();
+        expect(pendingButton).toHaveAttribute('aria-busy', 'true');
+        expect(pendingButton).toHaveStyle({ opacity: '0.65', cursor: 'not-allowed' });
+        expect(screen.getByRole('status')).toHaveTextContent('Signing in…');
+        expect(screen.getByRole('status')).toHaveStyle({ color: '#d4d4d8' });
+
+        resolveSignIn({ error: 'CredentialsSignin' });
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Sign In with Email' })).toBeEnabled());
     });
 });

--- a/__tests__/lib/auth.test.ts
+++ b/__tests__/lib/auth.test.ts
@@ -10,19 +10,78 @@ jest.mock('next-auth/providers/credentials', () => ({
 jest.mock('@auth/prisma-adapter', () => ({ PrismaAdapter: () => ({}) }));
 jest.mock('@/lib/prisma', () => ({ prisma: { user: { findUnique: jest.fn() } } }));
 jest.mock('bcryptjs', () => ({ compare: jest.fn() }));
+jest.mock('@/lib/authRateLimit', () => ({
+    consumeAuthRateLimit: jest.fn(),
+    clearAuthRateLimit: jest.fn(),
+}));
 
 // Imported after mocks so the mocked deps are wired in.
 import { authOptions } from '@/lib/auth';
+import { clearAuthRateLimit, consumeAuthRateLimit } from '@/lib/authRateLimit';
 
 const authorize = (authOptions.providers[0] as any).authorize as (
-    credentials: Record<string, string> | undefined
+    credentials: Record<string, string> | undefined,
+    request?: { headers?: Record<string, string | string[] | undefined> }
 ) => Promise<any>;
 
 const mockedPrisma = prisma as unknown as { user: { findUnique: jest.Mock } };
 const mockedCompare = bcrypt.compare as unknown as jest.Mock;
+const mockedConsumeRateLimit = consumeAuthRateLimit as jest.Mock;
+const mockedClearRateLimit = clearAuthRateLimit as jest.Mock;
 
 describe('authOptions credential authorize', () => {
-    beforeEach(() => jest.clearAllMocks());
+    beforeEach(() => {
+        jest.clearAllMocks();
+        delete process.env.AUTH_TRUSTED_PROXY_HOPS;
+        mockedConsumeRateLimit.mockResolvedValue({ allowed: true, retryAfterSeconds: 0 });
+    });
+
+    it('normalizes the email before rate limiting and account lookup', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue(null);
+        mockedCompare.mockResolvedValue(false);
+
+        await authorize({ email: '  Ada@Example.COM ', password: 'whatever12' }).catch(() => {});
+
+        expect(mockedConsumeRateLimit).toHaveBeenCalledWith('login-email', 'ada@example.com', {
+            limit: 5,
+            windowSeconds: 15 * 60,
+        });
+        expect(mockedPrisma.user.findUnique).toHaveBeenCalledWith({
+            where: { email: 'ada@example.com' },
+        });
+    });
+
+    it('does not let targeted failed-attempt counters lock out valid credentials', async () => {
+        mockedConsumeRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 60 });
+        mockedPrisma.user.findUnique.mockResolvedValue({
+            id: 'u1', email: 'ada@example.com', name: 'Ada', image: null,
+            password: 'real-hash', role: 'USER',
+        });
+        mockedCompare.mockResolvedValue(true);
+
+        const result = await authorize({ email: 'ada@example.com', password: 'correct-horse' });
+
+        expect(result).toMatchObject({ id: 'u1' });
+        expect(mockedClearRateLimit).toHaveBeenCalledWith('login-email', 'ada@example.com');
+    });
+
+    it('blocks rotating-email spray from a throttled trusted source before password work', async () => {
+        process.env.AUTH_TRUSTED_PROXY_HOPS = '1';
+        mockedConsumeRateLimit.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 60 });
+
+        const error = await authorize(
+            { email: 'randomized@example.com', password: 'whatever12' },
+            { headers: { 'x-forwarded-for': 'spoofed, 203.0.113.10' } }
+        ).catch(e => e);
+
+        expect(error.message).toBe('Invalid email or password');
+        expect(mockedConsumeRateLimit).toHaveBeenCalledWith('login-source', '203.0.113.10', {
+            limit: 20,
+            windowSeconds: 15 * 60,
+        });
+        expect(mockedPrisma.user.findUnique).not.toHaveBeenCalled();
+        expect(mockedCompare).not.toHaveBeenCalled();
+    });
 
     it('returns the same generic error for unknown user and wrong password (no enumeration)', async () => {
         // Unknown user
@@ -63,6 +122,7 @@ describe('authOptions credential authorize', () => {
 
         expect(result).toMatchObject({ id: 'u1', email: 'a@b.com', role: 'USER' });
         expect(result.password).toBeUndefined();
+        expect(mockedClearRateLimit).toHaveBeenCalledWith('login-email', 'a@b.com');
     });
 
     it('throws error when email or password is missing', async () => {

--- a/__tests__/lib/authRateLimit.test.ts
+++ b/__tests__/lib/authRateLimit.test.ts
@@ -1,0 +1,39 @@
+/** @jest-environment node */
+jest.mock('@/lib/prisma', () => ({
+    prisma: { $executeRaw: jest.fn() }
+}));
+
+import { createAuthRateLimitKey, pruneExpiredAuthRateLimits } from '@/lib/authRateLimit';
+import { prisma } from '@/lib/prisma';
+
+describe('authentication rate-limit keys', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('uses a stable keyed digest without retaining the email or IP address', () => {
+        const first = createAuthRateLimitKey('login-email', 'Ada@Example.com', 'test-secret');
+        const second = createAuthRateLimitKey('login-email', 'Ada@Example.com', 'test-secret');
+
+        expect(first).toBe(second);
+        expect(first).toMatch(/^login-email:[a-f0-9]{64}$/);
+        expect(first).not.toContain('Ada@Example.com');
+    });
+
+    it('separates actions and identifiers', () => {
+        expect(createAuthRateLimitKey('login-email', 'a@example.com', 'test-secret'))
+            .not.toBe(createAuthRateLimitKey('register-email', 'a@example.com', 'test-secret'));
+        expect(createAuthRateLimitKey('login-email', 'a@example.com', 'test-secret'))
+            .not.toBe(createAuthRateLimitKey('login-email', 'b@example.com', 'test-secret'));
+    });
+
+    it('prunes expired rows in bounded batches', async () => {
+        (prisma.$executeRaw as jest.Mock).mockResolvedValue(250);
+
+        await expect(pruneExpiredAuthRateLimits(250)).resolves.toBe(250);
+        expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects invalid cleanup batch sizes', async () => {
+        await expect(pruneExpiredAuthRateLimits(0)).rejects.toThrow('Cleanup limit must be a positive integer.');
+        expect(prisma.$executeRaw).not.toHaveBeenCalled();
+    });
+});

--- a/__tests__/lib/clientAddress.test.ts
+++ b/__tests__/lib/clientAddress.test.ts
@@ -1,0 +1,20 @@
+/** @jest-environment node */
+import { getTrustedClientAddress, hasTrustedProxyConfiguration } from '@/lib/clientAddress';
+
+describe('trusted client address resolution', () => {
+    it('ignores forwarding input when no trusted proxy contract is configured', () => {
+        expect(getTrustedClientAddress('198.51.100.1', '0')).toBeNull();
+        expect(hasTrustedProxyConfiguration('0')).toBe(false);
+    });
+
+    it('selects from the trusted right side of the forwarding chain', () => {
+        expect(getTrustedClientAddress('spoofed, 203.0.113.9', '1')).toBe('203.0.113.9');
+        expect(getTrustedClientAddress('client, proxy-one, proxy-two', '2')).toBe('proxy-one');
+    });
+
+    it('rejects malformed configuration and incomplete chains', () => {
+        expect(getTrustedClientAddress('203.0.113.9', 'many')).toBeNull();
+        expect(getTrustedClientAddress('203.0.113.9', '2')).toBeNull();
+        expect(hasTrustedProxyConfiguration('6')).toBe(false);
+    });
+});

--- a/__tests__/lib/env.test.ts
+++ b/__tests__/lib/env.test.ts
@@ -43,4 +43,18 @@ describe('validateServerEnvironment', () => {
             NEXTAUTH_SECRET: 'too-short',
         })).toThrow('NEXTAUTH_SECRET must be at least 32 characters');
     });
+
+    it('requires a trusted proxy contract in production', () => {
+        expect(() => validateServerEnvironment({
+            ...validEnvironment,
+            NODE_ENV: 'production',
+            AUTH_TRUSTED_PROXY_HOPS: '0',
+        })).toThrow('AUTH_TRUSTED_PROXY_HOPS must be between 1 and 5 in production');
+
+        expect(validateServerEnvironment({
+            ...validEnvironment,
+            NODE_ENV: 'production',
+            AUTH_TRUSTED_PROXY_HOPS: '1',
+        })).toMatchObject({ AUTH_TRUSTED_PROXY_HOPS: '1' });
+    });
 });

--- a/__tests__/security/containerEntrypoint.test.ts
+++ b/__tests__/security/containerEntrypoint.test.ts
@@ -7,6 +7,7 @@ const validEnvironment: NodeJS.ProcessEnv = {
     DATABASE_URL: 'postgresql://postgres:postgres@db:5432/travel_app',
     NEXTAUTH_URL: 'http://localhost:3000',
     NEXTAUTH_SECRET: 'a-secure-test-secret-that-is-at-least-32-characters',
+    AUTH_TRUSTED_PROXY_HOPS: '1',
 };
 
 function runEntrypoint(environment: NodeJS.ProcessEnv) {
@@ -21,7 +22,7 @@ describe('container entrypoint', () => {
         expect(runEntrypoint(validEnvironment).status).toBe(0);
     });
 
-    it.each(['DATABASE_URL', 'NEXTAUTH_URL', 'NEXTAUTH_SECRET'] as const)(
+    it.each(['DATABASE_URL', 'NEXTAUTH_URL', 'NEXTAUTH_SECRET', 'AUTH_TRUSTED_PROXY_HOPS'] as const)(
         'fails before startup when %s is missing',
         (key) => {
             const environment = { ...validEnvironment };
@@ -53,5 +54,13 @@ describe('container entrypoint', () => {
         expect(invalidDatabase.status).not.toBe(0);
         expect(invalidNextAuth.status).not.toBe(0);
         expect(shortSecret.status).not.toBe(0);
+    });
+
+    it('rejects an invalid trusted proxy hop count', () => {
+        const result = runEntrypoint({ ...validEnvironment, AUTH_TRUSTED_PROXY_HOPS: '0' });
+        expect(result.status).not.toBe(0);
+        expect(`${result.stdout}${result.stderr}`).toContain(
+            'AUTH_TRUSTED_PROXY_HOPS must be between 1 and 5'
+        );
     });
 });

--- a/__tests__/security/containerSecrets.test.ts
+++ b/__tests__/security/containerSecrets.test.ts
@@ -37,9 +37,28 @@ describe('container secret protection', () => {
 
     it('injects authentication configuration into the app container at runtime', () => {
         const composeFile = readRepositoryFile('docker-compose.yml');
+        const appService = composeFile.slice(
+            composeFile.indexOf('  app:'),
+            composeFile.indexOf('\n  proxy:')
+        );
 
         expect(composeFile).toContain('NEXTAUTH_URL: ${NEXTAUTH_URL:?NEXTAUTH_URL is required}');
         expect(composeFile).toContain('NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}');
+        expect(appService).toContain('AUTH_TRUSTED_PROXY_HOPS: "1"');
+        expect(appService).toContain('expose:');
+        expect(appService).not.toContain('ports:');
+    });
+
+    it('publishes the app only through a proxy that replaces forwarded client addresses', () => {
+        const composeFile = readRepositoryFile('docker-compose.yml');
+        const proxyConfiguration = readRepositoryFile('deploy/nginx.conf');
+
+        expect(composeFile).toContain('proxy:');
+        expect(composeFile).toContain('- "3000:8080"');
+        expect(composeFile).toContain('./deploy/nginx.conf:/etc/nginx/nginx.conf:ro');
+        expect(proxyConfiguration).toContain('proxy_pass http://app:3000;');
+        expect(proxyConfiguration).toContain('proxy_set_header X-Forwarded-For $remote_addr;');
+        expect(proxyConfiguration).not.toContain('$proxy_add_x_forwarded_for');
     });
 
     it('checks the final container image in CI', () => {
@@ -67,6 +86,7 @@ describe('container secret protection', () => {
         expect(exampleEnvironment).toContain('NEXTAUTH_URL=');
         expect(exampleEnvironment).toContain('NEXTAUTH_SECRET=');
         expect(exampleEnvironment.match(/^NEXTAUTH_SECRET=(.*)$/m)?.[1]).toBe('');
+        expect(exampleEnvironment).toContain('AUTH_TRUSTED_PROXY_HOPS=0');
         expect(securityGuide).toContain('Rotate exposed secrets');
         expect(securityGuide).toContain('Rebuild and redeploy');
     });

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -8,6 +8,15 @@ import {
     registrationSchema,
     validationErrorPayload
 } from '@/lib/validation';
+import { consumeAuthRateLimit } from '@/lib/authRateLimit';
+import {
+    getTrustedClientAddressFromHeaders,
+    hasTrustedProxyConfiguration
+} from '@/lib/clientAddress';
+
+const ACCEPTED_RESPONSE = {
+    message: 'If this address can be registered, the request has been accepted.'
+};
 
 export async function POST(req: Request) {
     try {
@@ -17,37 +26,60 @@ export async function POST(req: Request) {
             MAX_REGISTRATION_BYTES
         );
 
+        const clientAddress = getTrustedClientAddressFromHeaders(req.headers);
+        if (hasTrustedProxyConfiguration() && !clientAddress) {
+            return NextResponse.json({
+                error: {
+                    code: 'INVALID_CLIENT_SOURCE',
+                    message: 'Unable to process this account request.',
+                    fields: {}
+                }
+            }, { status: 400 });
+        }
+
+        const emailLimit = await consumeAuthRateLimit(
+            'register-email', email, { limit: 3, windowSeconds: 60 * 60 }
+        );
+        const addressLimit = clientAddress
+            ? await consumeAuthRateLimit(
+                'register-address', clientAddress, { limit: 50, windowSeconds: 60 * 60 }
+            )
+            : { allowed: true, retryAfterSeconds: 0 };
+        if (!emailLimit.allowed || !addressLimit.allowed) {
+            const retryAfterSeconds = Math.max(emailLimit.retryAfterSeconds, addressLimit.retryAfterSeconds);
+            return NextResponse.json({
+                error: {
+                    code: 'RATE_LIMITED',
+                    message: 'Too many account requests. Please try again later.',
+                    fields: {}
+                }
+            }, {
+                status: 429,
+                headers: { 'Retry-After': String(retryAfterSeconds) }
+            });
+        }
+
+        const hashedPassword = await bcrypt.hash(password, 10);
+
         const existingUser = await prisma.user.findUnique({
             where: { email },
         });
 
         if (existingUser) {
-            return NextResponse.json({
-                error: {
-                    code: 'ACCOUNT_EXISTS',
-                    message: 'An account already exists for that email address.',
-                    fields: { email: ['Use a different email address or sign in.'] }
-                }
-            }, { status: 409 });
+            return NextResponse.json(ACCEPTED_RESPONSE, { status: 202 });
         }
 
-        const hashedPassword = await bcrypt.hash(password, 10);
+        try {
+            await prisma.user.create({
+                data: { name, email, password: hashedPassword },
+            });
+        } catch (error) {
+            if (!(error && typeof error === 'object' && 'code' in error && error.code === 'P2002')) {
+                throw error;
+            }
+        }
 
-        const user = await prisma.user.create({
-            data: {
-                name,
-                email,
-                password: hashedPassword,
-            },
-        });
-
-        // Never return the password hash (or any other sensitive field) to the client.
-        const safeUser = { id: user.id, name: user.name, email: user.email, role: user.role };
-
-        return NextResponse.json(
-            { message: 'User registered successfully', user: safeUser },
-            { status: 201 }
-        );
+        return NextResponse.json(ACCEPTED_RESPONSE, { status: 202 });
     } catch (error) {
         if (error instanceof InputValidationError) {
             return NextResponse.json(

--- a/app/login/components/user-auth-form.tsx
+++ b/app/login/components/user-auth-form.tsx
@@ -14,19 +14,35 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
         message: string;
         fields: Record<string, string[]>;
     } | null>(null);
+    const [formNotice, setFormNotice] = React.useState<string | null>(null);
+    const errorSummaryRef = React.useRef<HTMLDivElement>(null);
     const router = useRouter();
+
+    const showFormError = (message: string, fields: Record<string, string[]> = {}) => {
+        setFormError({ message, fields });
+        window.setTimeout(() => {
+            const firstInvalidField = ['name', 'email', 'password']
+                .find(field => fields[field]?.length);
+            if (firstInvalidField) {
+                document.getElementById(firstInvalidField)?.focus();
+            } else {
+                errorSummaryRef.current?.focus();
+            }
+        }, 0);
+    };
 
     async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
         setIsLoading(true);
         setFormError(null);
+        setFormNotice(null);
         const formData = new FormData(event.currentTarget);
         const email = String(formData.get('email') ?? '');
         const password = String(formData.get('password') ?? '');
         const name = String(formData.get('name') ?? '');
 
-        if (type === "signup") {
-            try {
+        try {
+            if (type === "signup") {
                 const response = await fetch("/api/auth/register", {
                     method: "POST",
                     headers: {
@@ -41,35 +57,17 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
 
                 if (!response.ok) {
                     const payload = await response.json().catch(() => null);
-                    setFormError({
-                        message: payload?.error?.message ?? 'Unable to create your account.',
-                        fields: payload?.error?.fields ?? {}
-                    });
+                    showFormError(
+                        payload?.error?.message ?? 'Unable to create your account.',
+                        payload?.error?.fields ?? {}
+                    );
                     return;
                 }
 
-                // Auto sign-in after registration
-                const result = await signIn("credentials", {
-                    redirect: false,
-                    email,
-                    password,
-                });
-
-                if (result?.error) {
-                    console.error(result.error);
-                } else {
-                    router.push("/");
-                    router.refresh();
-                }
-
-            } catch (error) {
-                console.error(error);
-                setFormError({ message: 'Unable to create your account.', fields: {} });
-            } finally {
-                setIsLoading(false);
+                setFormNotice('If this address is eligible, you can now sign in with your credentials.');
+                return;
             }
-        } else {
-            // Handle login
+
             const result = await signIn("credentials", {
                 redirect: false,
                 email,
@@ -77,11 +75,16 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
             });
 
             if (result?.error) {
-                console.error(result.error);
+                showFormError('Invalid email or password.');
             } else {
                 router.push("/");
                 router.refresh();
             }
+        } catch {
+            showFormError(type === 'signup'
+                ? 'Unable to create your account right now. Please try again.'
+                : 'Unable to sign in right now. Please try again.');
+        } finally {
             setIsLoading(false);
         }
     }
@@ -172,7 +175,7 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                             placeholder="Password"
                             type="password"
                             autoCapitalize="none"
-                            autoComplete="current-password"
+                            autoComplete={type === 'signup' ? 'new-password' : 'current-password'}
                             autoCorrect="off"
                             disabled={isLoading}
                             aria-invalid={Boolean(formError?.fields.password)}
@@ -198,11 +201,22 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                         )}
                     </div>
                     {formError && (
-                        <div role="alert" style={{ color: '#f87171', fontSize: '0.875rem' }}>
+                        <div
+                            ref={errorSummaryRef}
+                            role="alert"
+                            tabIndex={-1}
+                            style={{ color: '#f87171', fontSize: '0.875rem', outline: '2px solid #f87171', outlineOffset: '2px' }}>
                             {formError.message}
                         </div>
                     )}
-                    <button disabled={isLoading} style={{
+                    {(isLoading || formNotice) && (
+                        <div role="status" aria-live="polite" style={{ color: formNotice ? '#86efac' : '#d4d4d8', fontSize: '0.875rem' }}>
+                            {isLoading
+                                ? (type === 'signup' ? 'Creating account…' : 'Signing in…')
+                                : formNotice}
+                        </div>
+                    )}
+                    <button disabled={isLoading} aria-busy={isLoading} style={{
                         display: "inline-flex",
                         alignItems: "center",
                         justifyContent: "center",
@@ -215,10 +229,13 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                         color: "#fafafa",
                         height: "2.5rem",
                         padding: "0.5rem 1rem",
-                        marginTop: "0.5rem"
+                        marginTop: "0.5rem",
+                        opacity: isLoading ? 0.65 : 1,
+                        cursor: isLoading ? 'not-allowed' : 'pointer'
                     }}>
                         {isLoading && (
                             <svg
+                                aria-hidden="true"
                                 className="mr-2 h-4 w-4 animate-spin"
                                 xmlns="http://www.w3.org/2000/svg"
                                 fill="none"
@@ -239,7 +256,9 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                                 ></path>
                             </svg>
                         )}
-                        {type === "signup" ? "Create account" : "Sign In with Email"}
+                        {isLoading
+                            ? (type === 'signup' ? 'Creating account…' : 'Signing in…')
+                            : (type === "signup" ? "Create account" : "Sign In with Email")}
                     </button>
                 </div>
             </form>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function AuthenticationPage() {
     return (
         <>
-            <div className="container relative hidden h-[800px] flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
+            <div className="container relative flex min-h-screen flex-col items-center justify-center px-4 lg:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
                 <Link
                     href="/signup"
                     className={"absolute right-4 top-4 md:right-8 md:top-8"}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function AuthenticationPage() {
     return (
         <>
-            <div className="container relative hidden h-[800px] flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
+            <div className="container relative flex min-h-screen flex-col items-center justify-center px-4 lg:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
                 <Link
                     href="/login"
                     className={"absolute right-4 top-4 md:right-8 md:top-8"}

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,26 @@
+pid /tmp/nginx.pid;
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+    server_tokens off;
+
+    server {
+        listen 8080;
+
+        location / {
+            proxy_pass http://app:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,26 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "3000:3000"
+    expose:
+      - "3000"
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/travel_app
       NEXTAUTH_URL: ${NEXTAUTH_URL:?NEXTAUTH_URL is required}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}
+      # The bundled proxy below is the single trusted right-most proxy.
+      AUTH_TRUSTED_PROXY_HOPS: "1"
     depends_on:
       migrate:
         condition: service_completed_successfully
+
+  proxy:
+    image: nginxinc/nginx-unprivileged:1.27-alpine
+    ports:
+      - "3000:8080"
+    volumes:
+      - ./deploy/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - app
 
   migrate:
     build:

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import { prisma } from '../lib/prisma';
 import FlightBookingService from '../lib/FlightBookingService';
 import { updateFlightSeatingLayout } from '../lib/FlightSeatLayoutService';
+import { registerAccount, registerAndSignIn, signInWithCredentials } from './helpers/auth';
 
 test.describe('Admin Control Journey', () => {
   const adminEmail = `admin-${Date.now()}@example.com`;
@@ -33,12 +34,7 @@ test.describe('Admin Control Journey', () => {
 
   test('Non-admin user is blocked from admin dashboard', async ({ page }) => {
     // Register standard user
-    await page.goto('/signup');
-    await page.fill('#name', 'Standard User');
-    await page.fill('#email', userEmail);
-    await page.fill('#password', password);
-    await page.click('button:has-text("Create account")');
-    await expect(page).toHaveURL('/');
+    await registerAndSignIn(page, { name: 'Standard User', email: userEmail, password });
 
     // Attempt to access admin page
     await page.goto('/admin');
@@ -50,12 +46,7 @@ test.describe('Admin Control Journey', () => {
 
   test('Admin user can access dashboard, create schedule, and change live status', async ({ page }) => {
     // Register admin user
-    await page.goto('/signup');
-    await page.fill('#name', 'Admin User');
-    await page.fill('#email', adminEmail);
-    await page.fill('#password', password);
-    await page.click('button:has-text("Create account")');
-    await expect(page).toHaveURL('/');
+    await registerAccount(page, { name: 'Admin User', email: adminEmail, password });
 
     // Promote the user to ADMIN directly in the database
     await prisma.user.update({
@@ -63,14 +54,7 @@ test.describe('Admin Control Journey', () => {
       data: { role: 'ADMIN' }
     });
 
-    // Logout and login again to refresh the JWT session token role
-    await page.click('button:has-text("Sign Out")');
-    await expect(page.locator('a:has-text("Sign In")')).toBeVisible();
-    await page.goto('/login');
-    await page.fill('#email', adminEmail);
-    await page.fill('#password', password);
-    await page.click('button:has-text("Sign In with Email")');
-    await expect(page).toHaveURL('/');
+    await signInWithCredentials(page, { email: adminEmail, password });
 
     // Access admin dashboard
     await page.goto('/admin');

--- a/e2e/auth-abuse.spec.ts
+++ b/e2e/auth-abuse.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+import { loadEnvConfig } from '@next/env';
+import { createAuthRateLimitKey } from '../lib/authRateLimit';
+import { prisma } from '../lib/prisma';
+
+loadEnvConfig(process.cwd());
+
+test.describe('Authentication abuse protection', () => {
+  const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const email = `Case-${suffix}@Example.com`;
+  const normalizedEmail = email.toLowerCase();
+  const unknownEmail = `unknown-${suffix}@example.com`;
+  const password = 'Password123!';
+  const rateLimitSecret = process.env.NEXTAUTH_SECRET;
+  if (!rateLimitSecret) {
+    throw new Error('NEXTAUTH_SECRET is required for authentication E2E cleanup.');
+  }
+  const registrationRateLimitKey = createAuthRateLimitKey(
+    'register-email',
+    normalizedEmail,
+    rateLimitSecret
+  );
+  const normalizedLoginRateLimitKey = createAuthRateLimitKey(
+    'login-email',
+    normalizedEmail,
+    rateLimitSecret
+  );
+  const rateLimitKeys = [
+    registrationRateLimitKey,
+    normalizedLoginRateLimitKey,
+    createAuthRateLimitKey('login-email', unknownEmail, rateLimitSecret)
+  ];
+
+  test.afterAll(async () => {
+    await prisma.user.deleteMany({ where: { email: normalizedEmail } });
+    await prisma.authRateLimit.deleteMany({
+      where: { key: { in: rateLimitKeys } }
+    });
+  });
+
+  test('normalizes case variants, keeps immediate responses generic, and rate limits abuse', async ({ page, request }) => {
+    const registrationBodies = [email, normalizedEmail, email.toUpperCase()];
+    for (const candidate of registrationBodies) {
+      const response = await request.post('/api/auth/register', {
+        data: { name: 'Case Traveler', email: candidate, password }
+      });
+      expect(response.status()).toBe(202);
+      expect(await response.json()).toEqual({
+        message: 'If this address can be registered, the request has been accepted.'
+      });
+    }
+
+    const blockedRegistration = await request.post('/api/auth/register', {
+      data: { name: 'Case Traveler', email, password }
+    });
+    expect(blockedRegistration.status()).toBe(429);
+    expect(await prisma.user.count({ where: { email: normalizedEmail } })).toBe(1);
+
+    const attemptLogin = async (candidateEmail: string) => {
+      await page.goto('/login');
+      await page.fill('#email', candidateEmail);
+      await page.fill('#password', 'DefinitelyWrong123!');
+      await page.click('button:has-text("Sign In with Email")');
+      await expect(page.locator('form').getByRole('alert')).toHaveText('Invalid email or password.');
+    };
+
+    await attemptLogin(normalizedEmail);
+    await attemptLogin(unknownEmail);
+    for (let attempt = 1; attempt < 6; attempt++) {
+      await attemptLogin(email.toUpperCase());
+    }
+
+    expect(await prisma.authRateLimit.findUnique({
+      where: { key: normalizedLoginRateLimitKey },
+      select: { attempts: true }
+    })).toEqual({ attempts: 6 });
+
+    await expect(prisma.user.create({
+      data: { name: 'Mixed Case', email: `Mixed-${suffix}@Example.com`, password: 'not-used' }
+    })).rejects.toThrow();
+  });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,27 +1,29 @@
 import { test, expect } from '@playwright/test';
+import { registerAccount, registerAndSignIn, signInWithCredentials } from './helpers/auth';
 
 test.describe('Authentication Journey', () => {
   const uniqueEmail = `test-${Date.now()}@example.com`;
   const name = 'Test User';
   const password = 'Password123!';
 
+  test('Login and signup remain usable at phone, tablet, and desktop widths', async ({ page }) => {
+    for (const width of [320, 768, 1280]) {
+      await page.setViewportSize({ width, height: 800 });
+      for (const path of ['/login', '/signup']) {
+        await page.goto(path);
+        const form = page.locator('form');
+        await expect(form).toBeVisible();
+        const box = await form.boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.x).toBeGreaterThanOrEqual(0);
+        expect(box!.x + box!.width).toBeLessThanOrEqual(width);
+      }
+    }
+  });
+
   test('User can register a new account', async ({ page }) => {
-    // Navigate to signup
-    await page.goto('/signup');
-
-    // Verify page content
-    await expect(page.locator('h1')).toContainText('Create an account');
-
-    // Fill registration form
-    await page.fill('#name', name);
-    await page.fill('#email', uniqueEmail);
-    await page.fill('#password', password);
-
-    // Submit form
-    await page.click('button:has-text("Create account")');
-
-    // Verify redirect to homepage and auto login (Sign Out button is visible)
-    await expect(page).toHaveURL('/');
+    await registerAccount(page, { name, email: uniqueEmail, password });
+    await signInWithCredentials(page, { email: uniqueEmail, password });
     await expect(page.locator('button:has-text("Sign Out")')).toBeVisible();
   });
 
@@ -29,12 +31,7 @@ test.describe('Authentication Journey', () => {
     const loginEmail = `login-test-${Date.now()}@example.com`;
 
     // Register a user specifically for this test to isolate state
-    await page.goto('/signup');
-    await page.fill('#name', name);
-    await page.fill('#email', loginEmail);
-    await page.fill('#password', password);
-    await page.click('button:has-text("Create account")');
-    await expect(page).toHaveURL('/');
+    await registerAndSignIn(page, { name, email: loginEmail, password });
 
     // Click logout
     await page.click('button:has-text("Sign Out")');

--- a/e2e/booking.spec.ts
+++ b/e2e/booking.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma } from '../lib/prisma';
+import { registerAndSignIn } from './helpers/auth';
 
 test.describe('Flight Booking Journey', () => {
   const uniqueEmail = `booktest-${Date.now()}@example.com`;
@@ -8,12 +9,7 @@ test.describe('Flight Booking Journey', () => {
 
   test.beforeEach(async ({ page }) => {
     // Register and login a fresh user to isolate the booking state
-    await page.goto('/signup');
-    await page.fill('#name', name);
-    await page.fill('#email', uniqueEmail);
-    await page.fill('#password', password);
-    await page.click('button:has-text("Create account")');
-    await expect(page).toHaveURL('/');
+    await registerAndSignIn(page, { name, email: uniqueEmail, password });
   });
 
   test.afterAll(async () => {

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,34 @@
+import { expect, Page } from '@playwright/test';
+
+export async function registerAccount(
+  page: Page,
+  account: { name: string; email: string; password: string }
+) {
+  await page.goto('/signup');
+  await page.fill('#name', account.name);
+  await page.fill('#email', account.email);
+  await page.fill('#password', account.password);
+  await page.click('button:has-text("Create account")');
+  await expect(page.locator('form').getByRole('status')).toHaveText(
+    'If this address is eligible, you can now sign in with your credentials.'
+  );
+}
+
+export async function signInWithCredentials(
+  page: Page,
+  account: { email: string; password: string }
+) {
+  await page.goto('/login');
+  await page.fill('#email', account.email);
+  await page.fill('#password', account.password);
+  await page.click('button:has-text("Sign In with Email")');
+  await expect(page).toHaveURL('/');
+}
+
+export async function registerAndSignIn(
+  page: Page,
+  account: { name: string; email: string; password: string }
+) {
+  await registerAccount(page, account);
+  await signInWithCredentials(page, account);
+}

--- a/e2e/multi-passenger.spec.ts
+++ b/e2e/multi-passenger.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { prisma } from '../lib/prisma';
 import { calculateBookingTotal } from '../lib/bookingPricing';
+import { registerAndSignIn } from './helpers/auth';
 
 test.describe('Multi-Passenger Booking Journey', () => {
   const uniqueEmail = `multibook-${Date.now()}@example.com`;
@@ -9,12 +10,7 @@ test.describe('Multi-Passenger Booking Journey', () => {
 
   test.beforeEach(async ({ page }) => {
     // Register and login a fresh user
-    await page.goto('/signup');
-    await page.fill('#name', name);
-    await page.fill('#email', uniqueEmail);
-    await page.fill('#password', password);
-    await page.click('button:has-text("Create account")');
-    await expect(page).toHaveURL('/');
+    await registerAndSignIn(page, { name, email: uniqueEmail, password });
   });
 
   test.afterAll(async () => {

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { prisma } from '../lib/prisma';
+import { registerAndSignIn } from './helpers/auth';
 
 test.describe('User Notifications & Alerts Journey', () => {
   const uniqueEmail = `notiftest-${Date.now()}@example.com`;
@@ -8,12 +9,7 @@ test.describe('User Notifications & Alerts Journey', () => {
 
   test.beforeEach(async ({ page }) => {
     // Register and login a fresh user to isolate notifications state
-    await page.goto('/signup');
-    await page.fill('#name', name);
-    await page.fill('#email', uniqueEmail);
-    await page.fill('#password', password);
-    await page.click('button:has-text("Create account")');
-    await expect(page).toHaveURL('/');
+    await registerAndSignIn(page, { name, email: uniqueEmail, password });
   });
 
   test.afterAll(async () => {

--- a/e2e/travelguide.spec.ts
+++ b/e2e/travelguide.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { registerAndSignIn } from './helpers/auth';
 
 test.describe('Travel Guide Journey', () => {
   const uniqueEmail = `guidetest-${Date.now()}@example.com`;
@@ -7,12 +8,7 @@ test.describe('Travel Guide Journey', () => {
 
   test.beforeEach(async ({ page }) => {
     // Register and login a fresh user to isolate favorites/reviews state
-    await page.goto('/signup');
-    await page.fill('#name', name);
-    await page.fill('#email', uniqueEmail);
-    await page.fill('#password', password);
-    await page.click('button:has-text("Create account")');
-    await expect(page).toHaveURL('/');
+    await registerAndSignIn(page, { name, email: uniqueEmail, password });
   });
 
   test('User can select a city, write a review, and toggle favorite', async ({ page }) => {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,6 +4,11 @@ import CredentialsProvider from 'next-auth/providers/credentials';
 import { PrismaAdapter } from '@auth/prisma-adapter';
 import { prisma } from '@/lib/prisma';
 import bcrypt from 'bcryptjs';
+import { clearAuthRateLimit, consumeAuthRateLimit } from '@/lib/authRateLimit';
+import {
+    getTrustedClientAddressFromHeaders,
+    hasTrustedProxyConfiguration
+} from '@/lib/clientAddress';
 
 // A valid bcrypt hash of a throwaway value, used only to equalize response
 // timing when no matching user exists (anti-enumeration). It is never a real
@@ -21,7 +26,7 @@ export const authOptions: NextAuthOptions = {
                 email: { label: 'Email', type: 'email', placeholder: 'user@example.com' },
                 password: { label: 'Password', type: 'password' },
             },
-            async authorize(credentials) {
+            async authorize(credentials, request) {
                 // Single generic message for every failure mode so the response
                 // never reveals whether an account with this email exists.
                 const INVALID = 'Invalid email or password';
@@ -30,8 +35,23 @@ export const authOptions: NextAuthOptions = {
                     throw new Error(INVALID);
                 }
 
+                const email = credentials.email.trim().toLowerCase();
+                const clientAddress = getTrustedClientAddressFromHeaders(request?.headers);
+                if (hasTrustedProxyConfiguration() && !clientAddress) throw new Error(INVALID);
+                if (clientAddress) {
+                    const sourceLimit = await consumeAuthRateLimit('login-source', clientAddress, {
+                        limit: 20,
+                        windowSeconds: 15 * 60,
+                    });
+                    if (!sourceLimit.allowed) throw new Error(INVALID);
+                }
+                await consumeAuthRateLimit('login-email', email, {
+                    limit: 5,
+                    windowSeconds: 15 * 60,
+                });
+
                 const user = await prisma.user.findUnique({
-                    where: { email: credentials.email },
+                    where: { email },
                 });
 
                 // Always run a bcrypt comparison — against the real hash when the
@@ -43,6 +63,8 @@ export const authOptions: NextAuthOptions = {
                 if (!user || !user.password || !isPasswordValid) {
                     throw new Error(INVALID);
                 }
+
+                await clearAuthRateLimit('login-email', email);
 
                 // Return only non-sensitive fields (never the password hash).
                 return {

--- a/lib/authRateLimit.ts
+++ b/lib/authRateLimit.ts
@@ -1,0 +1,77 @@
+import { createHmac } from 'crypto';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+
+export interface AuthRateLimitOptions {
+    limit: number;
+    windowSeconds: number;
+}
+
+export interface AuthRateLimitResult {
+    allowed: boolean;
+    retryAfterSeconds: number;
+}
+
+export function createAuthRateLimitKey(action: string, identifier: string, secret: string): string {
+    const digest = createHmac('sha256', secret).update(`${action}\0${identifier}`).digest('hex');
+    return `${action}:${digest}`;
+}
+
+export async function pruneExpiredAuthRateLimits(limit = 250): Promise<number> {
+    if (!Number.isInteger(limit) || limit < 1) {
+        throw new Error('Cleanup limit must be a positive integer.');
+    }
+    return prisma.$executeRaw(Prisma.sql`
+        WITH expired AS (
+            SELECT "key"
+            FROM "AuthRateLimit"
+            WHERE "expiresAt" <= CURRENT_TIMESTAMP
+            ORDER BY "expiresAt" ASC
+            LIMIT ${limit}
+        )
+        DELETE FROM "AuthRateLimit"
+        WHERE "key" IN (SELECT "key" FROM expired)
+    `);
+}
+
+function getRateLimitSecret(): string {
+    const secret = process.env.NEXTAUTH_SECRET?.trim();
+    if (!secret) throw new Error('Authentication rate limiting is not configured.');
+    return secret;
+}
+
+export async function consumeAuthRateLimit(
+    action: string,
+    identifier: string,
+    options: AuthRateLimitOptions
+): Promise<AuthRateLimitResult> {
+    await pruneExpiredAuthRateLimits();
+    const key = createAuthRateLimitKey(action, identifier, getRateLimitSecret());
+    const rows = await prisma.$queryRaw<Array<{ attempts: number; expiresAt: Date }>>(Prisma.sql`
+        INSERT INTO "AuthRateLimit" ("key", "attempts", "windowStart", "expiresAt")
+        VALUES (${key}, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + (${options.windowSeconds} * INTERVAL '1 second'))
+        ON CONFLICT ("key") DO UPDATE SET
+            "attempts" = CASE
+                WHEN "AuthRateLimit"."expiresAt" <= CURRENT_TIMESTAMP THEN 1
+                ELSE "AuthRateLimit"."attempts" + 1
+            END,
+            "windowStart" = CASE
+                WHEN "AuthRateLimit"."expiresAt" <= CURRENT_TIMESTAMP THEN CURRENT_TIMESTAMP
+                ELSE "AuthRateLimit"."windowStart"
+            END,
+            "expiresAt" = CASE
+                WHEN "AuthRateLimit"."expiresAt" <= CURRENT_TIMESTAMP
+                    THEN CURRENT_TIMESTAMP + (${options.windowSeconds} * INTERVAL '1 second')
+                ELSE "AuthRateLimit"."expiresAt"
+            END
+        RETURNING "attempts", "expiresAt"
+    `);
+    const row = rows[0];
+    const retryAfterSeconds = Math.max(1, Math.ceil((row.expiresAt.getTime() - Date.now()) / 1000));
+    return { allowed: row.attempts <= options.limit, retryAfterSeconds };
+}
+
+export async function clearAuthRateLimit(action: string, identifier: string): Promise<void> {
+    const key = createAuthRateLimitKey(action, identifier, getRateLimitSecret());
+    await prisma.$executeRaw(Prisma.sql`DELETE FROM "AuthRateLimit" WHERE "key" = ${key}`);
+}

--- a/lib/clientAddress.ts
+++ b/lib/clientAddress.ts
@@ -1,0 +1,28 @@
+type HeaderCollection = Headers | Record<string, string | string[] | undefined> | undefined;
+
+function readForwardedFor(headers: HeaderCollection): string | null {
+    if (!headers) return null;
+    if (headers instanceof Headers) return headers.get('x-forwarded-for');
+    const value = headers['x-forwarded-for'] ?? headers['X-Forwarded-For'];
+    return Array.isArray(value) ? value.join(',') : value ?? null;
+}
+
+export function hasTrustedProxyConfiguration(
+    configuredHops = process.env.AUTH_TRUSTED_PROXY_HOPS?.trim() ?? '0'
+): boolean {
+    return /^[1-5]$/.test(configuredHops);
+}
+
+export function getTrustedClientAddress(
+    forwardedFor: string | null | undefined,
+    configuredHops = process.env.AUTH_TRUSTED_PROXY_HOPS?.trim() ?? '0'
+): string | null {
+    if (!hasTrustedProxyConfiguration(configuredHops)) return null;
+    const chain = forwardedFor?.split(',').map(value => value.trim()).filter(Boolean) ?? [];
+    const clientIndex = chain.length - Number(configuredHops);
+    return clientIndex >= 0 ? chain[clientIndex] : null;
+}
+
+export function getTrustedClientAddressFromHeaders(headers: HeaderCollection): string | null {
+    return getTrustedClientAddress(readForwardedFor(headers));
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,6 +1,11 @@
 type RequiredEnvironmentVariable = 'DATABASE_URL' | 'NEXTAUTH_URL' | 'NEXTAUTH_SECRET';
-type Environment = Partial<Record<RequiredEnvironmentVariable, string | undefined>>;
-type ValidatedEnvironment = Record<RequiredEnvironmentVariable, string>;
+type Environment = Partial<Record<RequiredEnvironmentVariable, string | undefined>> & {
+    NODE_ENV?: string;
+    AUTH_TRUSTED_PROXY_HOPS?: string;
+};
+type ValidatedEnvironment = Record<RequiredEnvironmentVariable, string> & {
+    AUTH_TRUSTED_PROXY_HOPS?: string;
+};
 
 function requireValue(environment: Environment, key: RequiredEnvironmentVariable): string {
     const value = environment[key]?.trim();
@@ -45,5 +50,15 @@ export function validateServerEnvironment(environment: Environment): ValidatedEn
         throw new Error('NEXTAUTH_SECRET must be at least 32 characters');
     }
 
-    return { DATABASE_URL, NEXTAUTH_URL, NEXTAUTH_SECRET };
+    const AUTH_TRUSTED_PROXY_HOPS = environment.AUTH_TRUSTED_PROXY_HOPS?.trim();
+    if (environment.NODE_ENV === 'production' && !/^[1-5]$/.test(AUTH_TRUSTED_PROXY_HOPS ?? '')) {
+        throw new Error('AUTH_TRUSTED_PROXY_HOPS must be between 1 and 5 in production');
+    }
+
+    return {
+        DATABASE_URL,
+        NEXTAUTH_URL,
+        NEXTAUTH_SECRET,
+        ...(AUTH_TRUSTED_PROXY_HOPS ? { AUTH_TRUSTED_PROXY_HOPS } : {})
+    };
 }

--- a/prisma/migrations/20260713040000_auth_abuse_protection/migration.sql
+++ b/prisma/migrations/20260713040000_auth_abuse_protection/migration.sql
@@ -1,0 +1,30 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT LOWER(TRIM("email"))
+        FROM "User"
+        WHERE "email" IS NOT NULL
+        GROUP BY LOWER(TRIM("email"))
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'Cannot normalize user emails because case-variant duplicates exist';
+    END IF;
+END $$;
+
+UPDATE "User"
+SET "email" = LOWER(TRIM("email"))
+WHERE "email" IS NOT NULL;
+
+CREATE UNIQUE INDEX "User_email_normalized_key"
+ON "User" (LOWER("email"))
+WHERE "email" IS NOT NULL;
+
+CREATE TABLE "AuthRateLimit" (
+    "key" TEXT NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "AuthRateLimit_pkey" PRIMARY KEY ("key")
+);
+
+CREATE INDEX "AuthRateLimit_expiresAt_idx" ON "AuthRateLimit"("expiresAt");

--- a/prisma/migrations/20260713043000_enforce_canonical_email/migration.sql
+++ b/prisma/migrations/20260713043000_enforce_canonical_email/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "User"
+ADD CONSTRAINT "User_email_canonical_check"
+CHECK ("email" IS NULL OR "email" = LOWER(TRIM("email")));

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,15 @@ model VerificationToken {
   @@unique([identifier, token])
 }
 
+model AuthRateLimit {
+  key         String   @id
+  attempts    Int      @default(0)
+  windowStart DateTime
+  expiresAt   DateTime
+
+  @@index([expiresAt])
+}
+
 model CityGuide {
   id          Int      @id @default(autoincrement())
   city        String

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -15,6 +15,7 @@ require_value() {
 require_value DATABASE_URL
 require_value NEXTAUTH_URL
 require_value NEXTAUTH_SECRET
+require_value AUTH_TRUSTED_PROXY_HOPS
 
 case "$DATABASE_URL" in
   postgres://*|postgresql://*) ;;
@@ -36,5 +37,13 @@ if [ "${#NEXTAUTH_SECRET}" -lt 32 ]; then
   echo "NEXTAUTH_SECRET must be at least 32 characters" >&2
   exit 1
 fi
+
+case "$AUTH_TRUSTED_PROXY_HOPS" in
+  1|2|3|4|5) ;;
+  *)
+    echo "AUTH_TRUSTED_PROXY_HOPS must be between 1 and 5" >&2
+    exit 1
+    ;;
+esac
 
 exec "$@"


### PR DESCRIPTION
## Summary

Begin roadmap P0.5 by making email identity canonical, adding durable abuse
protection to registration and credential login, and keeping immediate signup
outcomes generic. This closes the most direct duplicate-account, enumeration,
and brute-force paths before verification and recovery are introduced in the
next P0.5 slice.

## Changes

- normalize email addresses in the application and database, including a
  database constraint and case-insensitive uniqueness migration
- add atomic PostgreSQL-backed registration and login rate limits with HMAC
  identifiers, bounded expiry pruning, and fail-closed trusted-proxy handling
- return the same immediate registration response for new and existing users
- make authentication pages responsive and improve pending, error, focus, and
  autocomplete accessibility states
- route the recommended Compose deployment only through a non-root nginx proxy
  that overwrites incoming `X-Forwarded-For` values
- add focused unit, component, migration, container, and Playwright abuse tests
- update the P0.5 roadmap progress entry and security/deployment guidance

Key decisions: source-address throttles trust forwarding headers only when an
explicit hop count is configured; per-email login attempts never lock out a
valid password; and limiter identifiers are keyed digests rather than raw
email or address values.

## Testing

- [x] Unit tests added/updated: 31 Jest suites, 254 tests
- [x] TypeScript typecheck and ESLint (0 errors; 8 inherited warnings)
- [x] Production dependency audit (0 vulnerabilities)
- [x] Prisma validate, generate, migration deploy, and migration status
- [x] Production Next.js build
- [x] Playwright: 12/12 journeys, including authentication abuse and phone,
  tablet, and desktop auth bounds
- [x] Docker build, secret/layer scan, non-root app and nginx startup, nginx
  routing, and spoofed-forwarding-header boundary
- [x] UI review: pass with no actionable findings
- [x] Pre-commit code review: pass with no actionable findings

Manual testing steps:

1. Register case variants of the same email and confirm generic responses and
   a single canonical account.
2. Exercise failed known and unknown login attempts and confirm identical
   user-facing errors and database-backed throttling.
3. Start the Compose app and confirm traffic reaches the app only through the
   bundled proxy at `http://localhost:3000`.

## Screenshots (if applicable)

No new visual design was introduced. Responsive and interaction states were
covered by component tests and Playwright viewport assertions; the UI reviewer
reported no remaining findings.

## Related Issues

Roadmap: P0.5 Harden identity and personal data (slice 1 of 3)
