### PR TITLE
feat(security): protect passenger identity data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/travel_app
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=
+# Comma-separated key-id:base64-key entries. The first 32-byte key is active;
+# retain older keys while rotating existing ciphertext. Generate a key with:
+# openssl rand -base64 32
+PASSENGER_DATA_ENCRYPTION_KEYS=
 # Direct local development does not trust forwarded addresses. The bundled
 # Docker proxy supplies its own production-safe value to the app container.
 AUTH_TRUSTED_PROXY_HOPS=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/travel_app
       NEXTAUTH_SECRET: ci-only-nextauth-secret-at-least-32-characters
       NEXTAUTH_URL: http://localhost:3000
+      PASSENGER_DATA_ENCRYPTION_KEYS: ci-v1:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
       AUTH_TRUSTED_PROXY_HOPS: 1
       AUTH_EMAIL_FROM: Mona Airways <no-reply@localhost>
       AUTH_EMAIL_PROVIDER: mailpit

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ cp .env.example .env
 ```
 
 Replace `NEXTAUTH_SECRET` with a securely generated value of at least 32
-characters. Local non-container development may leave
+characters. Generate the active passenger-data key with
+`openssl rand -base64 32` and set it as
+`PASSENGER_DATA_ENCRYPTION_KEYS=local-v1:<generated-value>`. Local
+non-container development may leave
 `AUTH_TRUSTED_PROXY_HOPS` at `0`. The recommended Compose deployment supplies
 its own safe value; other deployments must set it to the exact number of
 trusted right-most proxy entries. Deployed environments must inject all secret

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -102,7 +102,7 @@ Acceptance criteria:
 - [x] Add registration and authentication rate limits.
 - [x] Add email verification, password reset, and recovery flows.
 - [x] Use generic account-existence responses where appropriate.
-- [ ] Define encryption, access, retention, redaction, and deletion rules for
+- [x] Define encryption, access, retention, redaction, and deletion rules for
   passport numbers and dates of birth.
 - [ ] Add stronger protection for staff accounts.
 
@@ -485,3 +485,4 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-12 | P0.3 | Complete | #37 | Added shared Zod schemas, normalized mutation inputs, structured safe errors, and request/mutation limits. |
 | 2026-07-12 | P0.4 | Complete | #38 | Made server fares and inventory authoritative, removed fake payment identifiers, and added idempotent, concurrency-tested booking persistence. |
 | 2026-07-12 | P0.5 | In progress | #39 + #40 | Canonicalized email identity, added database-backed registration and login throttles, and implemented generic verified-email activation and password recovery journeys. Staff protection and passenger-data rules remain. |
+| 2026-07-14 | P0.5 | In progress | Pending | Added authenticated encryption, safe customer/staff projections, automated retention deletion and key rotation, and a tested passenger-data policy. Stronger staff protection remains. |

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -485,4 +485,4 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-12 | P0.3 | Complete | #37 | Added shared Zod schemas, normalized mutation inputs, structured safe errors, and request/mutation limits. |
 | 2026-07-12 | P0.4 | Complete | #38 | Made server fares and inventory authoritative, removed fake payment identifiers, and added idempotent, concurrency-tested booking persistence. |
 | 2026-07-12 | P0.5 | In progress | #39 + #40 | Canonicalized email identity, added database-backed registration and login throttles, and implemented generic verified-email activation and password recovery journeys. Staff protection and passenger-data rules remain. |
-| 2026-07-14 | P0.5 | In progress | Pending | Added authenticated encryption, safe customer/staff projections, automated retention deletion and key rotation, and a tested passenger-data policy. Stronger staff protection remains. |
+| 2026-07-14 | P0.5 | In progress | #42 | Added authenticated encryption, safe customer/staff projections, automated retention deletion and key rotation, and a tested passenger-data policy. Stronger staff protection remains. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,10 @@
   reachable around those ingresses.
 - Store deployment secrets in the hosting platform's secret manager and limit
   access to the people and workloads that require them.
+- Generate each `PASSENGER_DATA_ENCRYPTION_KEYS` entry as a random 32-byte key,
+  keep it separate from the database, and follow the access, rotation,
+  retention, and deletion rules in
+  [docs/PASSENGER_DATA_POLICY.md](docs/PASSENGER_DATA_POLICY.md).
 - Set `AUTH_EMAIL_PROVIDER=postmark`, configure `AUTH_EMAIL_FROM` and
   `AUTH_EMAIL_API_URL=https://api.postmarkapp.com/email`, and inject
   `AUTH_EMAIL_API_TOKEN` through the secret manager for deployed transactional

--- a/__tests__/components/AdminFlightsTable.test.tsx
+++ b/__tests__/components/AdminFlightsTable.test.tsx
@@ -40,8 +40,6 @@ const mockFlights = [
                         id: 'p1',
                         firstName: 'John',
                         lastName: 'Doe',
-                        dateOfBirth: '1990-01-01T00:00:00.000Z',
-                        passportNumber: 'P123',
                         gender: 'M',
                         seatNumber: '12A',
                         cabinClass: 'ECONOMY',
@@ -58,8 +56,6 @@ const mockFlights = [
                         id: 'p2',
                         firstName: 'Jane',
                         lastName: 'Smith',
-                        dateOfBirth: '1992-02-02T00:00:00.000Z',
-                        passportNumber: 'P456',
                         gender: 'F',
                         seatNumber: 'CANCELLED-12B',
                         cabinClass: 'BUSINESS',
@@ -165,13 +161,15 @@ describe('AdminFlightsTable', () => {
         // Passenger rows in table
         expect(screen.getByText('John Doe')).toBeInTheDocument();
         expect(screen.getByText('M')).toBeInTheDocument();
-        expect(screen.getByText('P123')).toBeInTheDocument();
+        expect(screen.queryByText('P123')).not.toBeInTheDocument();
         expect(screen.getByText('ECONOMY')).toBeInTheDocument();
         expect(screen.getByText('Seat 12A')).toBeInTheDocument();
         
         expect(screen.getByText('Jane Smith')).toBeInTheDocument();
         expect(screen.getByText('F')).toBeInTheDocument();
-        expect(screen.getByText('P456')).toBeInTheDocument();
+        expect(screen.queryByText('P456')).not.toBeInTheDocument();
+        expect(screen.queryByText('DOB')).not.toBeInTheDocument();
+        expect(screen.queryByText('Passport')).not.toBeInTheDocument();
         expect(screen.getByText('BUSINESS')).toBeInTheDocument();
         expect(screen.getByText('Released')).toBeInTheDocument();
 
@@ -203,9 +201,42 @@ describe('AdminFlightsTable', () => {
         expect(screen.getByText('No passengers booked on this occurrence.')).toBeInTheDocument();
 
         // Close via ✕ button
-        const closeCross = screen.getByRole('button', { name: '✕' });
+        const closeCross = screen.getByRole('button', { name: 'Close passenger manifest' });
         fireEvent.click(closeCross);
 
         expect(screen.queryByText('Passenger Manifest')).not.toBeInTheDocument();
+    });
+
+    it('provides accessible dialog semantics and restores focus when Escape closes the manifest', () => {
+        render(<AdminFlightsTable initialFlights={mockFlights} />);
+
+        const trigger = screen.getAllByRole('button', { name: 'Manifest' })[0];
+        fireEvent.click(trigger);
+
+        const dialog = screen.getByRole('dialog', { name: 'Passenger Manifest' });
+        const closeButton = screen.getByRole('button', { name: 'Close passenger manifest' });
+        expect(dialog).toHaveAttribute('aria-modal', 'true');
+        expect(closeButton).toHaveFocus();
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+
+        expect(screen.queryByRole('dialog', { name: 'Passenger Manifest' })).not.toBeInTheDocument();
+        expect(trigger).toHaveFocus();
+    });
+
+    it('keeps keyboard focus inside the open manifest', () => {
+        render(<AdminFlightsTable initialFlights={mockFlights} />);
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'Manifest' })[0]);
+        const closeButton = screen.getByRole('button', { name: 'Close passenger manifest' });
+        const footerCloseButton = screen.getByRole('button', { name: 'Close' });
+
+        footerCloseButton.focus();
+        fireEvent.keyDown(document, { key: 'Tab' });
+        expect(closeButton).toHaveFocus();
+
+        closeButton.focus();
+        fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+        expect(footerCloseButton).toHaveFocus();
     });
 });

--- a/__tests__/instrumentation.test.ts
+++ b/__tests__/instrumentation.test.ts
@@ -1,7 +1,11 @@
 jest.mock('@/lib/authTokens', () => ({ pruneExpiredAuthTokens: jest.fn() }));
+jest.mock('@/lib/passengerDataRetention', () => ({ purgeExpiredPassengerData: jest.fn() }));
+jest.mock('@/lib/passengerDataRotation', () => ({ rotatePassengerDataEncryptionBatch: jest.fn() }));
 
 import { register } from '@/instrumentation';
 import { pruneExpiredAuthTokens } from '@/lib/authTokens';
+import { purgeExpiredPassengerData } from '@/lib/passengerDataRetention';
+import { rotatePassengerDataEncryptionBatch } from '@/lib/passengerDataRotation';
 
 const originalEnvironment = process.env;
 
@@ -14,6 +18,7 @@ describe('server instrumentation', () => {
             DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/travel_app',
             NEXTAUTH_URL: 'http://localhost:3000',
             NEXTAUTH_SECRET: 'a-secure-test-secret-that-is-at-least-32-characters',
+            PASSENGER_DATA_ENCRYPTION_KEYS: 'test-v1:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
             AUTH_EMAIL_FROM: 'Mona Airways <no-reply@localhost>',
             AUTH_EMAIL_PROVIDER: 'mailpit',
             AUTH_EMAIL_API_URL: 'http://localhost:8025/api/v1/send',
@@ -25,14 +30,22 @@ describe('server instrumentation', () => {
             clearInterval(globalThis.authTokenPruneTimer);
             globalThis.authTokenPruneTimer = undefined;
         }
+        if (globalThis.passengerDataPurgeTimer) {
+            clearInterval(globalThis.passengerDataPurgeTimer);
+            globalThis.passengerDataPurgeTimer = undefined;
+        }
         process.env = originalEnvironment;
     });
 
     it('validates the environment and prunes expired auth tokens when the Node.js server starts', async () => {
         (pruneExpiredAuthTokens as jest.Mock).mockResolvedValue(0);
+        (purgeExpiredPassengerData as jest.Mock).mockResolvedValue(0);
+        (rotatePassengerDataEncryptionBatch as jest.Mock).mockResolvedValue(0);
 
         await expect(register()).resolves.toBeUndefined();
         expect(pruneExpiredAuthTokens).toHaveBeenCalled();
+        expect(purgeExpiredPassengerData).toHaveBeenCalled();
+        expect(rotatePassengerDataEncryptionBatch).toHaveBeenCalled();
     });
 
     it('fails startup when a required setting is absent', async () => {

--- a/__tests__/lib/FlightBookingService.test.ts
+++ b/__tests__/lib/FlightBookingService.test.ts
@@ -1,6 +1,8 @@
 /** @jest-environment node */
 import FlightBookingService, { PassengerInput } from '@/lib/FlightBookingService';
 import { prisma } from '@/lib/prisma';
+import { safePassengerSelect } from '@/lib/passengerDataAccess';
+import { encryptPassengerData } from '@/lib/passengerDataProtection';
 
 const mockTx = {
     $queryRaw: jest.fn(),
@@ -101,12 +103,20 @@ describe('FlightBookingService', () => {
                 userId: 'u1',
                 idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
             },
-            include: { passengers: true }
+            include: {
+                passengers: {
+                    select: {
+                        ...safePassengerSelect,
+                        dateOfBirthEncrypted: true,
+                        passportNumberEncrypted: true,
+                    }
+                }
+            }
         });
 
         expect(mockTx.booking.findMany).toHaveBeenCalledWith({
             where: { flightId: 7, status: { not: "CANCELLED" } },
-            include: { passengers: true }
+            include: { passengers: { select: { seatNumber: true } } }
         });
 
         expect(mockTx.booking.create).toHaveBeenCalledWith({
@@ -119,10 +129,12 @@ describe('FlightBookingService', () => {
                 passengers: {
                     create: [
                         {
+                            id: expect.any(String),
                             firstName: 'Alice',
                             lastName: 'Smith',
-                            dateOfBirth: new Date('1995-05-15'),
-                            passportNumber: 'US123456',
+                            dateOfBirthEncrypted: expect.stringMatching(/^v1:/),
+                            passportNumberEncrypted: expect.stringMatching(/^v1:/),
+                            sensitiveDataExpiresAt: new Date('2099-01-31T10:00:00.000Z'),
                             gender: 'Female',
                             seatNumber: '4C',
                             cabinClass: 'BUSINESS',
@@ -131,13 +143,14 @@ describe('FlightBookingService', () => {
                     ]
                 }
             },
-            include: { passengers: true }
+            include: { passengers: { select: safePassengerSelect } }
         });
 
         expect(result).toMatchObject({ id: 2, totalPrice: '$700' });
     });
 
     it('returns the existing booking when an idempotency key is retried', async () => {
+        const passengerId = 'passenger-1';
         const existing = {
             id: 12,
             userId: 'u1',
@@ -145,8 +158,11 @@ describe('FlightBookingService', () => {
             idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735',
             totalPrice: '$350',
             passengers: [{
-                firstName: 'Alice', lastName: 'Smith', dateOfBirth: new Date('1995-05-15T00:00:00.000Z'),
-                passportNumber: 'US123456', gender: 'Female', seatNumber: '11A', cabinClass: 'ECONOMY'
+                id: passengerId,
+                firstName: 'Alice', lastName: 'Smith',
+                dateOfBirthEncrypted: encryptPassengerData('1995-05-15', { passengerId, field: 'dateOfBirth' }),
+                passportNumberEncrypted: encryptPassengerData('US123456', { passengerId, field: 'passportNumber' }),
+                gender: 'Female', seatNumber: '11A', cabinClass: 'ECONOMY'
             }]
         };
         mockTx.flight.findUnique.mockResolvedValue({
@@ -168,12 +184,24 @@ describe('FlightBookingService', () => {
             idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735'
         });
 
-        expect(result).toEqual({ ...existing, wasCreated: false });
+        expect(result).toEqual({
+            ...existing,
+            passengers: [{
+                id: passengerId,
+                firstName: 'Alice',
+                lastName: 'Smith',
+                gender: 'Female',
+                seatNumber: '11A',
+                cabinClass: 'ECONOMY',
+            }],
+            wasCreated: false,
+        });
         expect(mockTx.booking.create).not.toHaveBeenCalled();
         expect(mockTx.booking.findMany).not.toHaveBeenCalled();
     });
 
     it('rejects reuse of an idempotency key for a different flight or passenger request', async () => {
+        const passengerId = 'passenger-2';
         const existing = {
             id: 12,
             userId: 'u1',
@@ -181,8 +209,11 @@ describe('FlightBookingService', () => {
             idempotencyKey: '8ea59a65-9251-45b3-95d0-3920c49f5735',
             totalPrice: '$350',
             passengers: [{
-                firstName: 'Alice', lastName: 'Smith', dateOfBirth: new Date('1995-05-15T00:00:00.000Z'),
-                passportNumber: 'US123456', gender: 'Female', seatNumber: '11A', cabinClass: 'ECONOMY'
+                id: passengerId,
+                firstName: 'Alice', lastName: 'Smith',
+                dateOfBirthEncrypted: encryptPassengerData('1995-05-15', { passengerId, field: 'dateOfBirth' }),
+                passportNumberEncrypted: encryptPassengerData('US123456', { passengerId, field: 'passportNumber' }),
+                gender: 'Female', seatNumber: '11A', cabinClass: 'ECONOMY'
             }]
         };
         mockTx.flight.findUnique.mockResolvedValue({

--- a/__tests__/lib/env.test.ts
+++ b/__tests__/lib/env.test.ts
@@ -7,6 +7,7 @@ const validEnvironment = {
     AUTH_EMAIL_FROM: 'Mona Airways <no-reply@localhost>',
     AUTH_EMAIL_PROVIDER: 'mailpit',
     AUTH_EMAIL_API_URL: 'http://localhost:8025/api/v1/send',
+    PASSENGER_DATA_ENCRYPTION_KEYS: `local:${Buffer.from('0123456789abcdef0123456789abcdef').toString('base64')}`,
 };
 
 describe('validateServerEnvironment', () => {
@@ -16,7 +17,7 @@ describe('validateServerEnvironment', () => {
 
     it.each([
         'DATABASE_URL', 'NEXTAUTH_URL', 'NEXTAUTH_SECRET', 'AUTH_EMAIL_FROM',
-        'AUTH_EMAIL_PROVIDER', 'AUTH_EMAIL_API_URL'
+        'AUTH_EMAIL_PROVIDER', 'AUTH_EMAIL_API_URL', 'PASSENGER_DATA_ENCRYPTION_KEYS'
     ] as const)(
         'rejects a missing %s',
         (key) => {
@@ -28,6 +29,13 @@ describe('validateServerEnvironment', () => {
             );
         }
     );
+
+    it('rejects malformed passenger-data encryption keys', () => {
+        expect(() => validateServerEnvironment({
+            ...validEnvironment,
+            PASSENGER_DATA_ENCRYPTION_KEYS: 'local:not-a-32-byte-key',
+        })).toThrow('PASSENGER_DATA_ENCRYPTION_KEYS');
+    });
 
     it('rejects a non-PostgreSQL database URL', () => {
         expect(() => validateServerEnvironment({

--- a/__tests__/lib/passengerDataAccess.test.ts
+++ b/__tests__/lib/passengerDataAccess.test.ts
@@ -1,0 +1,17 @@
+/** @jest-environment node */
+import { safePassengerSelect } from '@/lib/passengerDataAccess';
+
+describe('passenger data access projections', () => {
+    it('exposes only fields needed by routine customer and staff views', () => {
+        expect(safePassengerSelect).toEqual({
+            id: true,
+            firstName: true,
+            lastName: true,
+            gender: true,
+            seatNumber: true,
+            cabinClass: true,
+        });
+        expect(safePassengerSelect).not.toHaveProperty('dateOfBirthEncrypted');
+        expect(safePassengerSelect).not.toHaveProperty('passportNumberEncrypted');
+    });
+});

--- a/__tests__/lib/passengerDataProtection.database.test.ts
+++ b/__tests__/lib/passengerDataProtection.database.test.ts
@@ -1,0 +1,107 @@
+/** @jest-environment node */
+import FlightBookingService from '@/lib/FlightBookingService';
+import { prisma } from '@/lib/prisma';
+import { decryptPassengerData } from '@/lib/passengerDataProtection';
+import { purgeExpiredPassengerData } from '@/lib/passengerDataRetention';
+
+describe('passenger identity data in PostgreSQL', () => {
+    const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const email = `passenger-data-${suffix}@example.com`;
+    const flightNumber = `PD${suffix.slice(-6)}`;
+    let userId: string;
+    let flightId: number;
+    let bookingId: number;
+
+    beforeAll(async () => {
+        const user = await prisma.user.create({
+            data: { email, emailVerified: new Date(), name: 'Privacy Test' },
+        });
+        userId = user.id;
+        const flight = await prisma.flight.create({
+            data: {
+                flightNumber,
+                airline: 'Privacy Air',
+                from: 'SEA',
+                to: 'SFO',
+                departureDate: new Date('2099-01-01T10:00:00.000Z'),
+                price: '$100',
+                status: 'ON_TIME',
+                economyRows: 20,
+                seatPattern: 'ABC-DEF',
+            },
+        });
+        flightId = flight.id;
+    });
+
+    afterAll(async () => {
+        if (bookingId) await prisma.booking.deleteMany({ where: { id: bookingId } });
+        if (flightId) await prisma.flight.deleteMany({ where: { id: flightId } });
+        if (userId) await prisma.user.deleteMany({ where: { id: userId } });
+    });
+
+    it('stores only ciphertext, returns only safe fields, and purges on expiry', async () => {
+        const result = await new FlightBookingService().bookFlight({
+            flightId,
+            userId,
+            idempotencyKey: crypto.randomUUID(),
+            passengers: [{
+                firstName: 'Ada',
+                lastName: 'Lovelace',
+                dateOfBirth: '1990-01-01',
+                passportNumber: 'SECRET123',
+                gender: 'Female',
+                seatNumber: '11A',
+                cabinClass: 'ECONOMY',
+            }],
+        });
+        bookingId = result.id;
+        expect(result.passengers[0]).toEqual({
+            id: expect.any(String),
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            gender: 'Female',
+            seatNumber: '11A',
+            cabinClass: 'ECONOMY',
+        });
+
+        const [stored] = await prisma.$queryRaw<Array<{
+            id: string;
+            dateOfBirthEncrypted: string;
+            passportNumberEncrypted: string;
+        }>>`
+            SELECT "id", "dateOfBirthEncrypted", "passportNumberEncrypted"
+            FROM "Passenger"
+            WHERE "bookingId" = ${bookingId}
+        `;
+        expect(stored.dateOfBirthEncrypted).not.toContain('1990-01-01');
+        expect(stored.passportNumberEncrypted).not.toContain('SECRET123');
+        expect(decryptPassengerData(stored.dateOfBirthEncrypted, {
+            passengerId: stored.id,
+            field: 'dateOfBirth',
+        })).toBe('1990-01-01');
+        expect(decryptPassengerData(stored.passportNumberEncrypted, {
+            passengerId: stored.id,
+            field: 'passportNumber',
+        })).toBe('SECRET123');
+
+        const expiredAt = new Date('2026-01-01T00:00:00.000Z');
+        await prisma.passenger.update({
+            where: { id: stored.id },
+            data: { sensitiveDataExpiresAt: expiredAt },
+        });
+        await expect(purgeExpiredPassengerData(new Date('2026-01-02T00:00:00.000Z')))
+            .resolves.toBeGreaterThanOrEqual(1);
+        await expect(prisma.passenger.findUnique({
+            where: { id: stored.id },
+            select: {
+                dateOfBirthEncrypted: true,
+                passportNumberEncrypted: true,
+                sensitiveDataDeletedAt: true,
+            },
+        })).resolves.toMatchObject({
+            dateOfBirthEncrypted: null,
+            passportNumberEncrypted: null,
+            sensitiveDataDeletedAt: expect.any(Date),
+        });
+    });
+});

--- a/__tests__/lib/passengerDataProtection.test.ts
+++ b/__tests__/lib/passengerDataProtection.test.ts
@@ -1,0 +1,72 @@
+/** @jest-environment node */
+import {
+    decryptPassengerData,
+    encryptPassengerData,
+    getPassengerDataRetentionDeadline,
+    parsePassengerDataEncryptionKeys,
+} from '@/lib/passengerDataProtection';
+
+const ACTIVE_KEY = Buffer.from('0123456789abcdef0123456789abcdef').toString('base64');
+const OLD_KEY = Buffer.from('abcdef0123456789abcdef0123456789').toString('base64');
+
+describe('passenger data protection', () => {
+    it('encrypts with AES-GCM and decrypts with authenticated passenger context', () => {
+        const keys = parsePassengerDataEncryptionKeys(`active:${ACTIVE_KEY}`);
+        const context = { passengerId: 'passenger-1', field: 'passportNumber' as const };
+
+        const encrypted = encryptPassengerData('US123456', context, keys);
+
+        expect(encrypted).toMatch(/^v1:active:/);
+        expect(encrypted).not.toContain('US123456');
+        expect(decryptPassengerData(encrypted, context, keys)).toBe('US123456');
+        expect(() => decryptPassengerData(encrypted, {
+            passengerId: 'passenger-2',
+            field: 'passportNumber',
+        }, keys)).toThrow('Unable to decrypt passenger data');
+    });
+
+    it('uses a fresh IV for every encrypted value', () => {
+        const keys = parsePassengerDataEncryptionKeys(`active:${ACTIVE_KEY}`);
+        const context = { passengerId: 'passenger-1', field: 'dateOfBirth' as const };
+
+        expect(encryptPassengerData('1990-01-01', context, keys))
+            .not.toBe(encryptPassengerData('1990-01-01', context, keys));
+    });
+
+    it('rejects tampered ciphertext', () => {
+        const keys = parsePassengerDataEncryptionKeys(`active:${ACTIVE_KEY}`);
+        const context = { passengerId: 'passenger-1', field: 'passportNumber' as const };
+        const encrypted = encryptPassengerData('US123456', context, keys);
+        const parts = encrypted.split(':');
+        parts[3] = `${parts[3].slice(0, -1)}${parts[3].endsWith('A') ? 'B' : 'A'}`;
+
+        expect(() => decryptPassengerData(parts.join(':'), context, keys))
+            .toThrow('Unable to decrypt passenger data');
+    });
+
+    it('writes with the active key and reads values written by retained rotation keys', () => {
+        const oldOnly = parsePassengerDataEncryptionKeys(`old:${OLD_KEY}`);
+        const rotated = parsePassengerDataEncryptionKeys(`active:${ACTIVE_KEY},old:${OLD_KEY}`);
+        const context = { passengerId: 'passenger-1', field: 'passportNumber' as const };
+        const oldCiphertext = encryptPassengerData('US123456', context, oldOnly);
+
+        expect(encryptPassengerData('US123456', context, rotated)).toMatch(/^v1:active:/);
+        expect(decryptPassengerData(oldCiphertext, context, rotated)).toBe('US123456');
+    });
+
+    it.each([
+        '',
+        'missing-separator',
+        `bad id:${ACTIVE_KEY}`,
+        `wildcard_key:${ACTIVE_KEY}`,
+        'short:c2hvcnQ=',
+        `duplicate:${ACTIVE_KEY},duplicate:${OLD_KEY}`,
+    ])('rejects an invalid key ring: %s', (value) => {
+        expect(() => parsePassengerDataEncryptionKeys(value)).toThrow();
+    });
+
+    it('expires sensitive data thirty days after departure', () => {
+        expect(getPassengerDataRetentionDeadline(new Date('2026-08-01T10:00:00.000Z')))
+            .toEqual(new Date('2026-08-31T10:00:00.000Z'));
+    });
+});

--- a/__tests__/lib/passengerDataRetention.test.ts
+++ b/__tests__/lib/passengerDataRetention.test.ts
@@ -1,0 +1,54 @@
+/** @jest-environment node */
+import { prisma } from '@/lib/prisma';
+import {
+    purgeExpiredPassengerData,
+    purgePassengerDataForUser,
+} from '@/lib/passengerDataRetention';
+
+jest.mock('@/lib/prisma', () => ({
+    prisma: {
+        passenger: { updateMany: jest.fn() },
+    },
+}));
+
+const updateMany = prisma.passenger.updateMany as jest.Mock;
+
+describe('passenger data retention', () => {
+    beforeEach(() => updateMany.mockReset());
+
+    it('purges expired encrypted fields without deleting the booking record', async () => {
+        updateMany.mockResolvedValue({ count: 2 });
+        const now = new Date('2026-09-01T00:00:00.000Z');
+
+        await expect(purgeExpiredPassengerData(now)).resolves.toBe(2);
+        expect(updateMany).toHaveBeenCalledWith({
+            where: {
+                sensitiveDataDeletedAt: null,
+                sensitiveDataExpiresAt: { lte: now },
+            },
+            data: {
+                dateOfBirthEncrypted: null,
+                passportNumberEncrypted: null,
+                sensitiveDataDeletedAt: now,
+            },
+        });
+    });
+
+    it('supports immediate erasure for a customer deletion request', async () => {
+        updateMany.mockResolvedValue({ count: 1 });
+        const now = new Date('2026-07-14T00:00:00.000Z');
+
+        await expect(purgePassengerDataForUser('user-1', now)).resolves.toBe(1);
+        expect(updateMany).toHaveBeenCalledWith({
+            where: {
+                booking: { userId: 'user-1' },
+                sensitiveDataDeletedAt: null,
+            },
+            data: {
+                dateOfBirthEncrypted: null,
+                passportNumberEncrypted: null,
+                sensitiveDataDeletedAt: now,
+            },
+        });
+    });
+});

--- a/__tests__/lib/passengerDataRotation.test.ts
+++ b/__tests__/lib/passengerDataRotation.test.ts
@@ -1,0 +1,55 @@
+/** @jest-environment node */
+import { prisma } from '@/lib/prisma';
+import { encryptPassengerData, parsePassengerDataEncryptionKeys } from '@/lib/passengerDataProtection';
+import { rotatePassengerDataEncryptionBatch } from '@/lib/passengerDataRotation';
+
+jest.mock('@/lib/prisma', () => ({
+    prisma: {
+        passenger: {
+            findMany: jest.fn(),
+            updateMany: jest.fn(),
+        },
+        $transaction: jest.fn(callbacks => Promise.all(callbacks)),
+    },
+}));
+
+const findMany = prisma.passenger.findMany as jest.Mock;
+const updateMany = prisma.passenger.updateMany as jest.Mock;
+const ACTIVE_KEY = Buffer.from('0123456789abcdef0123456789abcdef').toString('base64');
+const OLD_KEY = Buffer.from('abcdef0123456789abcdef0123456789').toString('base64');
+
+describe('passenger data key rotation', () => {
+    const originalKeys = process.env.PASSENGER_DATA_ENCRYPTION_KEYS;
+
+    afterAll(() => {
+        process.env.PASSENGER_DATA_ENCRYPTION_KEYS = originalKeys;
+    });
+
+    it('re-encrypts retained ciphertext with the active key in bounded batches', async () => {
+        process.env.PASSENGER_DATA_ENCRYPTION_KEYS = `active:${ACTIVE_KEY},old:${OLD_KEY}`;
+        const oldKeys = parsePassengerDataEncryptionKeys(`old:${OLD_KEY}`);
+        const passengerId = 'passenger-1';
+        findMany.mockResolvedValue([{
+            id: passengerId,
+            dateOfBirthEncrypted: encryptPassengerData('1990-01-01', {
+                passengerId,
+                field: 'dateOfBirth',
+            }, oldKeys),
+            passportNumberEncrypted: encryptPassengerData('US123456', {
+                passengerId,
+                field: 'passportNumber',
+            }, oldKeys),
+        }]);
+        updateMany.mockResolvedValue({ count: 1 });
+
+        await expect(rotatePassengerDataEncryptionBatch(25)).resolves.toBe(1);
+        expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 25 }));
+        expect(updateMany).toHaveBeenCalledWith({
+            where: { id: passengerId, sensitiveDataDeletedAt: null },
+            data: {
+                dateOfBirthEncrypted: expect.stringMatching(/^v1:active:/),
+                passportNumberEncrypted: expect.stringMatching(/^v1:active:/),
+            },
+        });
+    });
+});

--- a/__tests__/security/containerEntrypoint.test.ts
+++ b/__tests__/security/containerEntrypoint.test.ts
@@ -7,6 +7,7 @@ const validEnvironment: NodeJS.ProcessEnv = {
     DATABASE_URL: 'postgresql://postgres:postgres@db:5432/travel_app',
     NEXTAUTH_URL: 'http://localhost:3000',
     NEXTAUTH_SECRET: 'a-secure-test-secret-that-is-at-least-32-characters',
+    PASSENGER_DATA_ENCRYPTION_KEYS: 'test-v1:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
     AUTH_TRUSTED_PROXY_HOPS: '1',
     AUTH_EMAIL_FROM: 'Mona Airways <no-reply@localhost>',
     AUTH_EMAIL_PROVIDER: 'mailpit',
@@ -27,7 +28,8 @@ describe('container entrypoint', () => {
 
     it.each([
         'DATABASE_URL', 'NEXTAUTH_URL', 'NEXTAUTH_SECRET', 'AUTH_TRUSTED_PROXY_HOPS',
-        'AUTH_EMAIL_FROM', 'AUTH_EMAIL_PROVIDER', 'AUTH_EMAIL_API_URL'
+        'AUTH_EMAIL_FROM', 'AUTH_EMAIL_PROVIDER', 'AUTH_EMAIL_API_URL',
+        'PASSENGER_DATA_ENCRYPTION_KEYS'
     ] as const)(
         'fails before startup when %s is missing',
         (key) => {

--- a/__tests__/security/containerSecrets.test.ts
+++ b/__tests__/security/containerSecrets.test.ts
@@ -44,6 +44,7 @@ describe('container secret protection', () => {
 
         expect(composeFile).toContain('NEXTAUTH_URL: ${NEXTAUTH_URL:?NEXTAUTH_URL is required}');
         expect(composeFile).toContain('NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}');
+        expect(composeFile).toContain('PASSENGER_DATA_ENCRYPTION_KEYS: ${PASSENGER_DATA_ENCRYPTION_KEYS:?PASSENGER_DATA_ENCRYPTION_KEYS is required}');
         expect(appService).toContain('AUTH_TRUSTED_PROXY_HOPS: "1"');
         expect(appService).toContain('AUTH_EMAIL_FROM:');
         expect(appService).toContain('AUTH_EMAIL_PROVIDER: mailpit');
@@ -99,6 +100,7 @@ describe('container secret protection', () => {
         expect(verificationScript).toContain('scan-image-layers.sh');
         expect(verificationScript).toContain('SECRET_SCAN_SENTINEL');
         expect(verificationScript).toContain('AUTH_EMAIL_API_TOKEN');
+        expect(verificationScript).toContain('PASSENGER_DATA_ENCRYPTION_KEYS');
     });
 
     it('provides safe configuration and secret-rotation guidance', () => {
@@ -109,6 +111,8 @@ describe('container secret protection', () => {
         expect(exampleEnvironment).toContain('NEXTAUTH_URL=');
         expect(exampleEnvironment).toContain('NEXTAUTH_SECRET=');
         expect(exampleEnvironment.match(/^NEXTAUTH_SECRET=(.*)$/m)?.[1]).toBe('');
+        expect(exampleEnvironment).toContain('PASSENGER_DATA_ENCRYPTION_KEYS=');
+        expect(exampleEnvironment.match(/^PASSENGER_DATA_ENCRYPTION_KEYS=(.*)$/m)?.[1]).toBe('');
         expect(exampleEnvironment).toContain('AUTH_TRUSTED_PROXY_HOPS=0');
         expect(exampleEnvironment).toContain('AUTH_EMAIL_FROM=');
         expect(exampleEnvironment).toContain('AUTH_EMAIL_PROVIDER=mailpit');

--- a/__tests__/security/passengerDataSchema.test.ts
+++ b/__tests__/security/passengerDataSchema.test.ts
@@ -1,0 +1,39 @@
+/** @jest-environment node */
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('passenger data storage schema', () => {
+    const schema = fs.readFileSync(path.join(process.cwd(), 'prisma/schema.prisma'), 'utf8');
+
+    it('does not define plaintext date-of-birth or passport columns', () => {
+        const passengerModel = schema.match(/model Passenger \{([\s\S]*?)\n\}/)?.[1] ?? '';
+
+        expect(passengerModel).toContain('dateOfBirthEncrypted');
+        expect(passengerModel).toContain('passportNumberEncrypted');
+        expect(passengerModel).not.toMatch(/^\s*dateOfBirth\s+/m);
+        expect(passengerModel).not.toMatch(/^\s*passportNumber\s+/m);
+    });
+
+    it('tracks expiry and deletion of sensitive passenger data', () => {
+        const passengerModel = schema.match(/model Passenger \{([\s\S]*?)\n\}/)?.[1] ?? '';
+
+        expect(passengerModel).toContain('sensitiveDataExpiresAt');
+        expect(passengerModel).toContain('sensitiveDataDeletedAt');
+    });
+
+    it('purges legacy plaintext columns in the migration', () => {
+        const migration = fs.readFileSync(path.join(
+            process.cwd(),
+            'prisma/migrations/20260714010000_protect_passenger_data/migration.sql',
+        ), 'utf8');
+
+        expect(migration).toContain('DROP COLUMN "dateOfBirth"');
+        expect(migration).toContain('DROP COLUMN "passportNumber"');
+        expect(migration).toContain('SET "sensitiveDataDeletedAt" = CURRENT_TIMESTAMP');
+        const constraintMigration = fs.readFileSync(path.join(
+            process.cwd(),
+            'prisma/migrations/20260714011000_enforce_passenger_data_state/migration.sql',
+        ), 'utf8');
+        expect(constraintMigration).toContain('Passenger_sensitive_data_state_check');
+    });
+});

--- a/__tests__/styles/responsiveDashboards.test.ts
+++ b/__tests__/styles/responsiveDashboards.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('dashboard responsive layout rules', () => {
+    const css = fs.readFileSync(path.join(process.cwd(), 'app/globals.css'), 'utf8');
+
+    it('lets profile and admin flex/grid children shrink within the viewport', () => {
+        expect(css).toContain('.profile, .admin {\n  min-width: 0;');
+        expect(css).toContain('.profile .content, .admin .content {\n  min-width: 0;');
+        expect(css).toContain('.admin-flights-layout > * {\n  min-width: 0;');
+        expect(css).toContain('.profile .profile-card, .admin .admin-card {\n  min-width: 0;');
+    });
+
+    it('stacks the profile and uses viewport-safe padding on narrow screens', () => {
+        expect(css).toContain('@media (max-width: 900px) {\n  .profile {\n    flex-direction: column;');
+        expect(css).toContain('.profile .sidebar-menu {\n    width: 100%;\n    flex-basis: auto;');
+        expect(css).toContain('.page-container.admin {\n    padding-left: 1rem !important;');
+    });
+
+    it('contains the shared titlebar navigation on phone-sized screens', () => {
+        expect(css).toContain('@media (max-width: 600px) {\n  header {\n    flex-wrap: wrap;');
+        expect(css).toContain('header nav {\n    width: 100%;\n    min-width: 0;\n    overflow-x: auto;');
+        expect(css).toContain('header nav ul {\n    width: max-content;\n    gap: 1rem !important;');
+        expect(css).toContain('header nav ul li {\n    margin-left: 0;');
+    });
+});

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -234,7 +234,8 @@ export async function cancelBookingAction(bookingId: number) {
         if (lockedBooking.status === "CANCELLED") throw new Error("Booking is already cancelled");
 
         const passengers = await tx.passenger.findMany({
-            where: { bookingId }
+            where: { bookingId },
+            select: { id: true, seatNumber: true },
         });
         
         for (const passenger of passengers) {
@@ -287,7 +288,7 @@ export async function changeBookingSeatsAction(
 
     const booking = await prisma.booking.findUnique({
         where: { id: bookingId },
-        include: { passengers: true, flight: true }
+        include: { flight: true }
     });
     if (!booking) throw new Error("Booking not found");
 
@@ -303,7 +304,10 @@ export async function changeBookingSeatsAction(
         await lockFlightForUpdate(tx, flightId);
         const lockedBooking = await tx.booking.findUnique({
             where: { id: bookingId },
-            include: { passengers: true }
+            select: {
+                status: true,
+                passengers: { select: { id: true, cabinClass: true } },
+            }
         });
         if (!lockedBooking) throw new Error("Booking not found");
         if (lockedBooking.status === "CANCELLED") {

--- a/app/admin/flights/AdminFlightsTable.tsx
+++ b/app/admin/flights/AdminFlightsTable.tsx
@@ -1,14 +1,12 @@
 "use client"
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import FlightStatusSelector from './FlightStatusSelector';
 
 interface Passenger {
     id: string;
     firstName: string;
     lastName: string;
-    dateOfBirth: Date | string;
-    passportNumber: string;
     gender: string;
     seatNumber: string;
     cabinClass: string;
@@ -40,6 +38,56 @@ interface AdminFlightsTableProps {
 
 export default function AdminFlightsTable({ initialFlights }: AdminFlightsTableProps) {
     const [selectedFlight, setSelectedFlight] = useState<Flight | null>(null);
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const closeButtonRef = useRef<HTMLButtonElement>(null);
+    const manifestTriggerRef = useRef<HTMLButtonElement | null>(null);
+
+    const closeManifest = () => setSelectedFlight(null);
+
+    useEffect(() => {
+        if (!selectedFlight) return;
+
+        const trigger = manifestTriggerRef.current;
+        closeButtonRef.current?.focus();
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeManifest();
+                return;
+            }
+
+            if (event.key !== 'Tab' || !dialogRef.current) return;
+
+            const focusableElements = Array.from(
+                dialogRef.current.querySelectorAll<HTMLElement>(
+                    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+                )
+            );
+            const firstElement = focusableElements[0];
+            const lastElement = focusableElements[focusableElements.length - 1];
+
+            if (!firstElement || !lastElement) {
+                event.preventDefault();
+                dialogRef.current.focus();
+            } else if (event.shiftKey && document.activeElement === firstElement) {
+                event.preventDefault();
+                lastElement.focus();
+            } else if (!event.shiftKey && document.activeElement === lastElement) {
+                event.preventDefault();
+                firstElement.focus();
+            } else if (!dialogRef.current.contains(document.activeElement)) {
+                event.preventDefault();
+                firstElement.focus();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            trigger?.focus();
+        };
+    }, [selectedFlight]);
 
     const manifestPassengers = selectedFlight
         ? selectedFlight.bookings.flatMap(b =>
@@ -110,7 +158,10 @@ export default function AdminFlightsTable({ initialFlights }: AdminFlightsTableP
                                         </td>
                                         <td style={{ padding: '12px', textAlign: 'right' }}>
                                             <button
-                                                onClick={() => setSelectedFlight(flight)}
+                                                onClick={(event) => {
+                                                    manifestTriggerRef.current = event.currentTarget;
+                                                    setSelectedFlight(flight);
+                                                }}
                                                 style={{
                                                     color: '#fff',
                                                     border: 'none',
@@ -157,7 +208,13 @@ export default function AdminFlightsTable({ initialFlights }: AdminFlightsTableP
                     justifyContent: 'center',
                     padding: '1rem'
                 }}>
-                    <div style={{
+                    <div
+                        ref={dialogRef}
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby="passenger-manifest-title"
+                        tabIndex={-1}
+                        style={{
                         background: 'linear-gradient(135deg, #131127 0%, #200f28 100%)',
                         border: '1px solid rgba(255, 255, 255, 0.1)',
                         borderRadius: '24px',
@@ -172,7 +229,7 @@ export default function AdminFlightsTable({ initialFlights }: AdminFlightsTableP
                         {/* Header */}
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem', borderBottom: '1px solid rgba(255, 255, 255, 0.08)', paddingBottom: '12px' }}>
                             <div>
-                                <h2 style={{ fontSize: '1.5rem', color: '#c084fc', margin: 0, fontWeight: 'bold' }}>
+                                <h2 id="passenger-manifest-title" style={{ fontSize: '1.5rem', color: '#c084fc', margin: 0, fontWeight: 'bold' }}>
                                     Passenger Manifest
                                 </h2>
                                 <p suppressHydrationWarning style={{ fontSize: '0.9rem', color: 'rgba(255, 255, 255, 0.5)', margin: '4px 0 0 0' }}>
@@ -180,7 +237,9 @@ export default function AdminFlightsTable({ initialFlights }: AdminFlightsTableP
                                 </p>
                             </div>
                             <button 
-                                onClick={() => setSelectedFlight(null)}
+                                ref={closeButtonRef}
+                                onClick={closeManifest}
+                                aria-label="Close passenger manifest"
                                 style={{ background: 'none', border: 'none', color: 'rgba(255,255,255,0.6)', fontSize: '1.5rem', cursor: 'pointer' }}
                             >
                                 ✕
@@ -224,8 +283,6 @@ export default function AdminFlightsTable({ initialFlights }: AdminFlightsTableP
                                     <tr style={{ borderBottom: '2px solid rgba(255, 255, 255, 0.08)' }}>
                                         <th style={{ padding: '8px 12px', color: '#a78bfa', fontSize: '0.8rem', textTransform: 'uppercase' }}>Passenger</th>
                                         <th style={{ padding: '8px 12px', color: '#a78bfa', fontSize: '0.8rem', textTransform: 'uppercase' }}>Gender</th>
-                                        <th style={{ padding: '8px 12px', color: '#a78bfa', fontSize: '0.8rem', textTransform: 'uppercase' }}>DOB</th>
-                                        <th style={{ padding: '8px 12px', color: '#a78bfa', fontSize: '0.8rem', textTransform: 'uppercase' }}>Passport</th>
                                         <th style={{ padding: '8px 12px', color: '#a78bfa', fontSize: '0.8rem', textTransform: 'uppercase' }}>Class / Seat</th>
                                         <th style={{ padding: '8px 12px', color: '#a78bfa', fontSize: '0.8rem', textTransform: 'uppercase' }}>Booking Status</th>
                                     </tr>
@@ -241,12 +298,6 @@ export default function AdminFlightsTable({ initialFlights }: AdminFlightsTableP
                                                     </td>
                                                     <td style={{ padding: '10px 12px', fontSize: '0.85rem', color: 'rgba(255, 255, 255, 0.7)' }}>
                                                         {passenger.gender}
-                                                    </td>
-                                                    <td suppressHydrationWarning style={{ padding: '10px 12px', fontSize: '0.85rem', color: 'rgba(255, 255, 255, 0.7)' }}>
-                                                        {new Date(passenger.dateOfBirth).toLocaleDateString()}
-                                                    </td>
-                                                    <td style={{ padding: '10px 12px', fontSize: '0.85rem', color: 'rgba(255, 255, 255, 0.7)' }}>
-                                                        {passenger.passportNumber}
                                                     </td>
                                                     <td style={{ padding: '10px 12px', fontSize: '0.85rem' }}>
                                                         <div>{passenger.cabinClass}</div>
@@ -268,7 +319,7 @@ export default function AdminFlightsTable({ initialFlights }: AdminFlightsTableP
                                         })
                                     ) : (
                                         <tr>
-                                            <td colSpan={6} style={{ padding: '24px', textAlign: 'center', color: 'rgba(255, 255, 255, 0.4)' }}>
+                                            <td colSpan={4} style={{ padding: '24px', textAlign: 'center', color: 'rgba(255, 255, 255, 0.4)' }}>
                                                 No passengers booked on this occurrence.
                                             </td>
                                         </tr>
@@ -280,7 +331,7 @@ export default function AdminFlightsTable({ initialFlights }: AdminFlightsTableP
                         {/* Footer */}
                         <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '1.5rem', borderTop: '1px solid rgba(255, 255, 255, 0.08)', paddingTop: '1rem' }}>
                             <button
-                                onClick={() => setSelectedFlight(null)}
+                                onClick={closeManifest}
                                 style={{
                                     background: 'rgba(255, 255, 255, 0.05)',
                                     border: '1px solid rgba(255, 255, 255, 0.1)',

--- a/app/admin/flights/page.tsx
+++ b/app/admin/flights/page.tsx
@@ -5,6 +5,7 @@ import FlightScheduleForm from '@/components/ui/flightScheduleForm';
 import DeleteScheduleButton from './DeleteScheduleButton';
 import AdminFlightsTable from './AdminFlightsTable';
 import ManualOccurrenceBuilder from '@/components/ui/ManualOccurrenceBuilder';
+import { safePassengerSelect } from '@/lib/passengerDataAccess';
 
 export const dynamic = 'force-dynamic';
 
@@ -28,7 +29,7 @@ export default async function AdminFlightsPage() {
         include: {
             bookings: {
                 include: {
-                    passengers: true
+                    passengers: { select: safePassengerSelect }
                 }
             }
         },

--- a/app/globals.css
+++ b/app/globals.css
@@ -349,6 +349,7 @@ button:active, button[type="submit"]:active {
 
 /* User Profile & Admin Dashboards (Unified Glassmorphism) */
 .profile, .admin {
+  min-width: 0;
   display: flex;
   width: 100%;
   max-width: 1200px;
@@ -380,12 +381,15 @@ button:active, button[type="submit"]:active {
 }
 
 .profile .content, .admin .content {
+  min-width: 0;
   flex: 1;
   padding: 0;
   max-width: 100%;
 }
 
 .profile .profile-card, .admin .admin-card {
+  min-width: 0;
+  max-width: 100%;
   background: rgba(255, 255, 255, 0.03);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
@@ -435,6 +439,10 @@ button:active, button[type="submit"]:active {
   gap: 2rem;
 }
 
+.admin-flights-layout > * {
+  min-width: 0;
+}
+
 .admin-form-grid {
   display: grid;
   gap: 1rem;
@@ -449,15 +457,81 @@ button:active, button[type="submit"]:active {
 }
 
 @media (max-width: 900px) {
+  .profile {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .profile .sidebar-menu {
+    width: 100%;
+    flex-basis: auto;
+  }
+
+  .profile .content,
+  .admin .content {
+    width: 100%;
+  }
+
+  .page-container.admin {
+    padding-left: 1rem !important;
+    padding-right: 1rem !important;
+  }
+
+  .page-container.admin > div:first-child {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
   .admin-flights-layout {
     grid-template-columns: minmax(0, 1fr);
+    width: 100%;
   }
 }
 
 @media (max-width: 600px) {
+  header {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 12px 16px;
+  }
+
+  header .logo {
+    width: 100%;
+    min-width: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  header nav {
+    width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+  }
+
+  header nav ul {
+    width: max-content;
+    gap: 1rem !important;
+    padding-bottom: 0.25rem;
+  }
+
+  header nav ul li {
+    margin-left: 0;
+    flex: 0 0 auto;
+  }
+
   .admin-form-grid--two,
   .admin-form-grid--three {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .profile .profile-card,
+  .admin .admin-card,
+  .profile .sidebar-menu {
+    padding: 1rem;
   }
 }
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import ProfileClient from "@/components/ui/ProfileClient";
+import { safePassengerSelect } from "@/lib/passengerDataAccess";
 
 export const dynamic = 'force-dynamic';
 
@@ -22,7 +23,10 @@ export default async function ProfilePage() {
   const userBookings = await prisma.booking.findMany({
     where: { userId },
     orderBy: { createdAt: "desc" },
-    include: { flight: true, passengers: true },
+    include: {
+      flight: true,
+      passengers: { select: safePassengerSelect },
+    },
   });
 
   const userFavorites = await prisma.userFavorite.findMany({

--- a/components/ui/ProfileClient.tsx
+++ b/components/ui/ProfileClient.tsx
@@ -29,8 +29,6 @@ interface Passenger {
     id: string;
     firstName: string;
     lastName: string;
-    dateOfBirth: Date | string;
-    passportNumber: string;
     gender: string;
     seatNumber: string;
     cabinClass: string;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/travel_app
       NEXTAUTH_URL: ${NEXTAUTH_URL:?NEXTAUTH_URL is required}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}
+      PASSENGER_DATA_ENCRYPTION_KEYS: ${PASSENGER_DATA_ENCRYPTION_KEYS:?PASSENGER_DATA_ENCRYPTION_KEYS is required}
       # The bundled proxy below is the single trusted right-most proxy.
       AUTH_TRUSTED_PROXY_HOPS: "1"
       AUTH_EMAIL_FROM: "${AUTH_EMAIL_FROM:-Mona Airways <no-reply@localhost>}"

--- a/docs/PASSENGER_DATA_POLICY.md
+++ b/docs/PASSENGER_DATA_POLICY.md
@@ -1,0 +1,59 @@
+# Passenger Identity Data Policy
+
+Passport numbers and dates of birth are restricted identity data. They are
+collected only to create a booking and must not be reused for analytics,
+marketing, or routine customer-support work.
+
+## Storage and encryption
+
+- The database stores these fields only as versioned AES-256-GCM ciphertext.
+  A fresh 12-byte random IV protects every value, and authenticated context
+  binds each ciphertext to its passenger record and field.
+- `PASSENGER_DATA_ENCRYPTION_KEYS` is a comma-separated key ring in
+  `key-id:base64-key` form. The first key encrypts new values; retained keys
+  decrypt older values during rotation. Key IDs use only letters, numbers, and
+  hyphens; every key must be 32 random bytes.
+- Keys must be generated with a cryptographically secure generator and stored
+  in the deployment secret manager, separately from the database. They must
+  never be committed, logged, or baked into an image.
+- A suspected exposure requires an immediate new active key, re-encryption of
+  retained records, revocation of the affected key after old backups age out,
+  and an incident review.
+- On startup and hourly, the application re-encrypts bounded batches written
+  with retained keys using the active key. Remove a retired key only after no
+  live records use it and every backup that requires it has aged out.
+
+## Access and redaction
+
+- Booking creation is the only normal write path. Plaintext exists only in the
+  request-scoped server process long enough to validate and encrypt it.
+- Customer profiles receive passenger names and travel-assignment fields, but
+  never encrypted or plaintext passport numbers or dates of birth.
+- Routine administration manifests use the same safe projection. Access to an
+  admin route alone is not sufficient to reveal restricted identity data.
+- Booking action results, logs, errors, notifications, analytics, and routine
+  API responses must not contain either plaintext or ciphertext values.
+- Any future operational reveal flow requires a separately authorized,
+  audited, purpose-limited action with step-up staff authentication.
+
+## Retention and deletion
+
+- Restricted identity data expires 30 days after scheduled departure. The
+  application purges expired ciphertext at startup and hourly while retaining
+  non-sensitive booking, passenger, and seat history.
+- A verified customer erasure request can call the server-only
+  `purgePassengerDataForUser` operation immediately. The customer-facing
+  export/deletion workflow remains tracked separately under P5.3.
+- Deleting a booking deletes its passenger rows through the existing database
+  cascade. Database backups follow the deployment backup-retention policy and
+  must age out before a retired decryption key is destroyed.
+- The migration deliberately purges identity values from pre-production demo
+  rows because migration tooling must never receive the runtime encryption
+  key. Bookings and seat assignments remain intact.
+
+## Verification
+
+Automated checks cover authenticated encryption, unique IVs, tamper detection,
+key-ring validation, retention purging, safe view projections, and removal of
+plaintext schema columns. Browser coverage confirms routine staff journeys do
+not expose restricted identity data.

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -96,19 +96,87 @@ test.describe('Admin Control Journey', () => {
     await expect(flightRow.locator('text=0 / 180')).toBeVisible();
     await expect(flightRow.locator('text=0.0% full')).toBeVisible();
 
+    // Persist a real protected passenger so the browser journey proves the
+    // database-to-RSC-to-DOM projection never exposes restricted fields.
+    const activeOccurrence = await prisma.flight.findFirstOrThrow({
+      where: {
+        flightNumber: 'E2E606',
+        departureDate: { gt: new Date() }
+      },
+      orderBy: { departureDate: 'asc' }
+    });
+    const admin = await prisma.user.findUniqueOrThrow({ where: { email: adminEmail } });
+    await new FlightBookingService().bookFlight({
+      flightId: activeOccurrence.id,
+      userId: admin.id,
+      passengers: [{
+        firstName: 'Manifest',
+        lastName: 'Traveler',
+        dateOfBirth: '1988-04-12',
+        passportNumber: 'E2EMANIFEST123',
+        gender: 'Other',
+        seatNumber: '11A',
+        cabinClass: 'ECONOMY'
+      }],
+      idempotencyKey: 'de45ec8a-4ae2-4ac7-aa64-e8d9588963c2'
+    });
+    const protectedPassenger = await prisma.passenger.findFirstOrThrow({
+      where: {
+        booking: { userId: admin.id, flightId: activeOccurrence.id }
+      }
+    });
+    const restrictedValues = [
+      '1988-04-12',
+      'E2EMANIFEST123',
+      protectedPassenger.dateOfBirthEncrypted!,
+      protectedPassenger.passportNumberEncrypted!
+    ];
+
+    const profileResponse = await page.goto('/profile');
+    expect(profileResponse?.ok()).toBe(true);
+    const profileResponseBody = await profileResponse!.text();
+    const profileVisibleText = await page.locator('body').innerText();
+    await expect(page.getByText('Manifest (11A)')).toBeVisible();
+    for (const value of restrictedValues) {
+      expect(profileResponseBody).not.toContain(value);
+      expect(profileVisibleText).not.toContain(value);
+    }
+    expect(profileVisibleText).not.toContain('Passport');
+    expect(profileVisibleText).not.toContain('DOB');
+
+    const adminFlightsResponse = await page.goto('/admin/flights');
+    expect(adminFlightsResponse?.ok()).toBe(true);
+    const adminFlightsResponseBody = await adminFlightsResponse!.text();
+    const adminVisibleText = await page.locator('body').innerText();
+    for (const value of restrictedValues) {
+      expect(adminFlightsResponseBody).not.toContain(value);
+      expect(adminVisibleText).not.toContain(value);
+    }
+
+    const populatedFlightRow = page.locator('table').nth(1)
+      .locator(`tr:has-text("${activeOccurrence.flightNumber}"):has-text("1 Active")`).first();
+    await expect(populatedFlightRow.locator('text=1 Active')).toBeVisible();
+    await expect(populatedFlightRow.locator('text=1 / 180')).toBeVisible();
+
     // Click Manifest button
-    await flightRow.locator('button:has-text("Manifest")').click();
+    await populatedFlightRow.locator('button:has-text("Manifest")').click();
 
     // Verify manifest modal opens
     await expect(page.locator('h2:has-text("Passenger Manifest")')).toBeVisible();
-    await expect(page.locator('text=No passengers booked on this occurrence.')).toBeVisible();
+    await expect(page.getByText('Manifest Traveler')).toBeVisible();
+    const manifestText = await page.getByRole('dialog', { name: 'Passenger Manifest' }).innerText();
+    for (const value of restrictedValues) {
+      expect(manifestText).not.toContain(value);
+    }
+    expect(manifestText).not.toContain('Passport');
+    expect(manifestText).not.toContain('DOB');
 
     // Close manifest modal
     await page.locator('button:has-text("Close")').click();
     await expect(page.locator('h2:has-text("Passenger Manifest")')).not.toBeVisible();
 
     // Select the newly generated flight's live status selector and change to "Delayed"
-    const statusSelect = flightRow.locator('select').first();
+    const statusSelect = populatedFlightRow.locator('select').first();
     await expect(statusSelect).toBeVisible();
     await statusSelect.selectOption('DELAYED');
 
@@ -197,7 +265,6 @@ test.describe('Admin Control Journey', () => {
         seatPattern: 'ABC-DEF'
       }
     });
-    const admin = await prisma.user.findUniqueOrThrow({ where: { email: adminEmail } });
     const raceResults = await Promise.allSettled([
       updateFlightSeatingLayout(raceFlight.id, {
         firstClassRows: 4,

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,18 +1,23 @@
-import { validateServerEnvironment } from '@/lib/env';
-
 const AUTH_TOKEN_PRUNE_INTERVAL_MS = 60 * 60 * 1_000;
 const AUTH_TOKEN_PRUNE_BATCH_SIZE = 250;
 const AUTH_TOKEN_PRUNE_MAX_BATCHES = 20;
+const PASSENGER_DATA_PURGE_INTERVAL_MS = 60 * 60 * 1_000;
+const PASSENGER_DATA_ROTATION_BATCH_SIZE = 100;
+const PASSENGER_DATA_ROTATION_MAX_BATCHES = 20;
 
 declare global {
     // One timer per Node.js process, including during development reloads.
     var authTokenPruneTimer: NodeJS.Timeout | undefined;
+    var passengerDataPurgeTimer: NodeJS.Timeout | undefined;
 }
 
 export async function register() {
     if (process.env.NEXT_RUNTIME === 'nodejs') {
+        const { validateServerEnvironment } = await import('@/lib/env');
         validateServerEnvironment(process.env);
         const { pruneExpiredAuthTokens } = await import('@/lib/authTokens');
+        const { purgeExpiredPassengerData } = await import('@/lib/passengerDataRetention');
+        const { rotatePassengerDataEncryptionBatch } = await import('@/lib/passengerDataRotation');
         const pruneBacklog = async () => {
             for (let batch = 0; batch < AUTH_TOKEN_PRUNE_MAX_BATCHES; batch += 1) {
                 const deleted = await pruneExpiredAuthTokens(AUTH_TOKEN_PRUNE_BATCH_SIZE);
@@ -20,6 +25,14 @@ export async function register() {
             }
         };
         await pruneBacklog();
+        await purgeExpiredPassengerData();
+        const rotatePassengerDataBacklog = async () => {
+            for (let batch = 0; batch < PASSENGER_DATA_ROTATION_MAX_BATCHES; batch += 1) {
+                const rotated = await rotatePassengerDataEncryptionBatch(PASSENGER_DATA_ROTATION_BATCH_SIZE);
+                if (rotated < PASSENGER_DATA_ROTATION_BATCH_SIZE) break;
+            }
+        };
+        await rotatePassengerDataBacklog();
         if (!globalThis.authTokenPruneTimer) {
             globalThis.authTokenPruneTimer = setInterval(() => {
                 pruneBacklog().catch(() => {
@@ -27,6 +40,20 @@ export async function register() {
                 });
             }, AUTH_TOKEN_PRUNE_INTERVAL_MS);
             globalThis.authTokenPruneTimer.unref?.();
+        }
+        if (!globalThis.passengerDataPurgeTimer) {
+            globalThis.passengerDataPurgeTimer = setInterval(() => {
+                const maintainPassengerData = async () => {
+                    // Purge first and rotate second so a rotation can never
+                    // restore ciphertext erased by the retention job.
+                    await purgeExpiredPassengerData();
+                    await rotatePassengerDataBacklog();
+                };
+                maintainPassengerData().catch(() => {
+                    console.error('Unable to maintain protected passenger identity data.');
+                });
+            }, PASSENGER_DATA_PURGE_INTERVAL_MS);
+            globalThis.passengerDataPurgeTimer.unref?.();
         }
     }
 }

--- a/lib/FlightBookingService.ts
+++ b/lib/FlightBookingService.ts
@@ -1,8 +1,15 @@
+import { randomUUID } from 'node:crypto';
 import { prisma } from '@/lib/prisma';
 import { assertSeatAvailableForCabin } from '@/lib/seatLayout';
 import { lockFlightForUpdate } from '@/lib/flightLock';
 import { flightBookingServiceSchema, parseInput } from '@/lib/validation';
 import { calculateBookingTotal } from '@/lib/bookingPricing';
+import { safePassengerSelect } from '@/lib/passengerDataAccess';
+import {
+    decryptPassengerData,
+    encryptPassengerData,
+    getPassengerDataRetentionDeadline,
+} from '@/lib/passengerDataProtection';
 
 export interface PassengerInput {
   firstName: string;
@@ -29,16 +36,39 @@ function passengerRequestSignature(passenger: PassengerInput): string {
     ]);
 }
 
+interface ProtectedPassenger extends Omit<PassengerInput, 'dateOfBirth' | 'passportNumber'> {
+    id: string;
+    dateOfBirthEncrypted: string | null;
+    passportNumberEncrypted: string | null;
+}
+
+function protectedPassengerRequestSignature(passenger: ProtectedPassenger): string {
+    if (!passenger.dateOfBirthEncrypted || !passenger.passportNumberEncrypted) {
+        throw new Error('Passenger identity data is no longer available.');
+    }
+    return passengerRequestSignature({
+        ...passenger,
+        dateOfBirth: decryptPassengerData(passenger.dateOfBirthEncrypted, {
+            passengerId: passenger.id,
+            field: 'dateOfBirth',
+        }),
+        passportNumber: decryptPassengerData(passenger.passportNumberEncrypted, {
+            passengerId: passenger.id,
+            field: 'passportNumber',
+        }),
+    });
+}
+
 function matchesPersistedRequest(
     existingFlightId: number | null,
-    existingPassengers: PassengerInput[],
+    existingPassengers: ProtectedPassenger[],
     flightId: number,
     passengers: PassengerInput[]
 ): boolean {
     if (existingFlightId !== flightId || existingPassengers.length !== passengers.length) {
         return false;
     }
-    const existingSignatures = existingPassengers.map(passengerRequestSignature).sort();
+    const existingSignatures = existingPassengers.map(protectedPassengerRequestSignature).sort();
     const requestedSignatures = passengers.map(passengerRequestSignature).sort();
     return existingSignatures.every((signature, index) => signature === requestedSignatures[index]);
 }
@@ -63,7 +93,15 @@ export default class FlightBookingService {
 
             const existingRequest = await tx.booking.findFirst({
                 where: { userId, idempotencyKey },
-                include: { passengers: true }
+                include: {
+                    passengers: {
+                        select: {
+                            ...safePassengerSelect,
+                            dateOfBirthEncrypted: true,
+                            passportNumberEncrypted: true,
+                        }
+                    }
+                }
             });
             if (existingRequest) {
                 if (!matchesPersistedRequest(
@@ -74,7 +112,18 @@ export default class FlightBookingService {
                 )) {
                     throw new Error('Booking request ID was already used for a different booking.');
                 }
-                return { ...existingRequest, wasCreated: false };
+                return {
+                    ...existingRequest,
+                    passengers: existingRequest.passengers.map(passenger => ({
+                        id: passenger.id,
+                        firstName: passenger.firstName,
+                        lastName: passenger.lastName,
+                        gender: passenger.gender,
+                        seatNumber: passenger.seatNumber,
+                        cabinClass: passenger.cabinClass,
+                    })),
+                    wasCreated: false,
+                };
             }
 
             if (flight.status === 'CANCELLED' || flight.departureDate.getTime() <= Date.now()) {
@@ -97,7 +146,7 @@ export default class FlightBookingService {
 
             const existingBookings = await tx.booking.findMany({
                 where: { flightId, status: { not: "CANCELLED" } },
-                include: { passengers: true }
+                include: { passengers: { select: { seatNumber: true } } }
             });
 
             const occupiedSeats = new Set(
@@ -119,6 +168,30 @@ export default class FlightBookingService {
                 }))
             );
 
+            const sensitiveDataExpiresAt = getPassengerDataRetentionDeadline(flight.departureDate);
+            const protectedPassengers = passengers.map(passenger => {
+                const id = randomUUID();
+                const dateOfBirth = passenger.dateOfBirth.slice(0, 10);
+                return {
+                    id,
+                    firstName: passenger.firstName,
+                    lastName: passenger.lastName,
+                    dateOfBirthEncrypted: encryptPassengerData(dateOfBirth, {
+                        passengerId: id,
+                        field: 'dateOfBirth',
+                    }),
+                    passportNumberEncrypted: encryptPassengerData(passenger.passportNumber, {
+                        passengerId: id,
+                        field: 'passportNumber',
+                    }),
+                    sensitiveDataExpiresAt,
+                    gender: passenger.gender,
+                    seatNumber: passenger.seatNumber,
+                    cabinClass: passenger.cabinClass,
+                    flightId,
+                };
+            });
+
             // Create booking with nested passengers
             const booking = await tx.booking.create({
                 data: {
@@ -128,20 +201,11 @@ export default class FlightBookingService {
                     paymentIntentId: null,
                     idempotencyKey,
                     passengers: {
-                        create: passengers.map(p => ({
-                            firstName: p.firstName,
-                            lastName: p.lastName,
-                            dateOfBirth: new Date(p.dateOfBirth),
-                            passportNumber: p.passportNumber,
-                            gender: p.gender,
-                            seatNumber: p.seatNumber,
-                            cabinClass: p.cabinClass,
-                            flightId
-                        }))
+                        create: protectedPassengers
                     }
                 },
                 include: {
-                    passengers: true
+                    passengers: { select: safePassengerSelect }
                 }
             });
             return { ...booking, wasCreated: true };

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,10 +1,13 @@
+import { parsePassengerDataEncryptionKeys } from '@/lib/passengerDataProtection';
+
 type RequiredEnvironmentVariable =
     | 'DATABASE_URL'
     | 'NEXTAUTH_URL'
     | 'NEXTAUTH_SECRET'
     | 'AUTH_EMAIL_FROM'
     | 'AUTH_EMAIL_PROVIDER'
-    | 'AUTH_EMAIL_API_URL';
+    | 'AUTH_EMAIL_API_URL'
+    | 'PASSENGER_DATA_ENCRYPTION_KEYS';
 type Environment = Partial<Record<RequiredEnvironmentVariable, string | undefined>> & {
     NODE_ENV?: string;
     AUTH_TRUSTED_PROXY_HOPS?: string;
@@ -40,6 +43,8 @@ export function validateServerEnvironment(environment: Environment): ValidatedEn
     const AUTH_EMAIL_FROM = requireValue(environment, 'AUTH_EMAIL_FROM');
     const AUTH_EMAIL_PROVIDER = requireValue(environment, 'AUTH_EMAIL_PROVIDER');
     const AUTH_EMAIL_API_URL = requireValue(environment, 'AUTH_EMAIL_API_URL');
+    const PASSENGER_DATA_ENCRYPTION_KEYS = requireValue(environment, 'PASSENGER_DATA_ENCRYPTION_KEYS');
+    parsePassengerDataEncryptionKeys(PASSENGER_DATA_ENCRYPTION_KEYS);
 
     const databaseUrl = parseUrl(DATABASE_URL, 'DATABASE_URL');
     if (!['postgresql:', 'postgres:'].includes(databaseUrl.protocol)) {
@@ -98,6 +103,7 @@ export function validateServerEnvironment(environment: Environment): ValidatedEn
         AUTH_EMAIL_FROM,
         AUTH_EMAIL_PROVIDER,
         AUTH_EMAIL_API_URL,
+        PASSENGER_DATA_ENCRYPTION_KEYS,
         ...(AUTH_EMAIL_API_TOKEN ? { AUTH_EMAIL_API_TOKEN } : {}),
         ...(AUTH_TRUSTED_PROXY_HOPS ? { AUTH_TRUSTED_PROXY_HOPS } : {})
     };

--- a/lib/passengerDataAccess.ts
+++ b/lib/passengerDataAccess.ts
@@ -1,0 +1,10 @@
+import type { Prisma } from '@prisma/client';
+
+export const safePassengerSelect = {
+    id: true,
+    firstName: true,
+    lastName: true,
+    gender: true,
+    seatNumber: true,
+    cabinClass: true,
+} satisfies Prisma.PassengerSelect;

--- a/lib/passengerDataProtection.ts
+++ b/lib/passengerDataProtection.ts
@@ -1,0 +1,123 @@
+import {
+    createCipheriv,
+    createDecipheriv,
+    randomBytes,
+} from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const ENVELOPE_VERSION = 'v1';
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+const RETENTION_DAYS = 30;
+// Rotation uses the envelope prefix in a SQL LIKE-backed `startsWith` filter,
+// so key IDs must not contain LIKE wildcards such as `_` or `%`.
+const KEY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]{0,31}$/;
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+export type PassengerSensitiveField = 'dateOfBirth' | 'passportNumber';
+
+export interface PassengerDataContext {
+    passengerId: string;
+    field: PassengerSensitiveField;
+}
+
+export interface PassengerDataEncryptionKeys {
+    activeKeyId: string;
+    keys: ReadonlyMap<string, Buffer>;
+}
+
+function configurationError(message: string): Error {
+    return new Error(`PASSENGER_DATA_ENCRYPTION_KEYS ${message}`);
+}
+
+export function parsePassengerDataEncryptionKeys(value: string): PassengerDataEncryptionKeys {
+    const entries = value.trim().split(',').map(entry => entry.trim()).filter(Boolean);
+    if (entries.length === 0) {
+        throw configurationError('must contain at least one key');
+    }
+
+    const keys = new Map<string, Buffer>();
+    for (const entry of entries) {
+        const separator = entry.indexOf(':');
+        if (separator <= 0 || separator === entry.length - 1) {
+            throw configurationError('must use key-id:base64-key entries');
+        }
+        const keyId = entry.slice(0, separator);
+        const encodedKey = entry.slice(separator + 1);
+        if (!KEY_ID_PATTERN.test(keyId)) {
+            throw configurationError('contains an invalid key identifier');
+        }
+        if (keys.has(keyId)) {
+            throw configurationError(`contains duplicate key identifier ${keyId}`);
+        }
+        if (!BASE64_PATTERN.test(encodedKey)) {
+            throw configurationError(`contains invalid base64 for key ${keyId}`);
+        }
+        const key = Buffer.from(encodedKey, 'base64');
+        if (key.length !== 32) {
+            throw configurationError(`key ${keyId} must decode to exactly 32 bytes`);
+        }
+        keys.set(keyId, key);
+    }
+
+    return { activeKeyId: entries[0].slice(0, entries[0].indexOf(':')), keys };
+}
+
+export function getConfiguredPassengerDataEncryptionKeys(): PassengerDataEncryptionKeys {
+    return parsePassengerDataEncryptionKeys(process.env.PASSENGER_DATA_ENCRYPTION_KEYS ?? '');
+}
+
+function additionalAuthenticatedData(context: PassengerDataContext): Buffer {
+    return Buffer.from(`travel-app:passenger:${context.passengerId}:${context.field}`, 'utf8');
+}
+
+export function encryptPassengerData(
+    plaintext: string,
+    context: PassengerDataContext,
+    keyRing = getConfiguredPassengerDataEncryptionKeys(),
+): string {
+    const key = keyRing.keys.get(keyRing.activeKeyId);
+    if (!key) throw configurationError('does not contain its active key');
+
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_BYTES });
+    cipher.setAAD(additionalAuthenticatedData(context));
+    const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    return [
+        ENVELOPE_VERSION,
+        keyRing.activeKeyId,
+        iv.toString('base64url'),
+        ciphertext.toString('base64url'),
+        authTag.toString('base64url'),
+    ].join(':');
+}
+
+export function decryptPassengerData(
+    envelope: string,
+    context: PassengerDataContext,
+    keyRing = getConfiguredPassengerDataEncryptionKeys(),
+): string {
+    try {
+        const [version, keyId, encodedIv, encodedCiphertext, encodedAuthTag, ...extra] = envelope.split(':');
+        if (version !== ENVELOPE_VERSION || extra.length > 0) throw new Error('Invalid envelope');
+        const key = keyRing.keys.get(keyId);
+        if (!key) throw new Error('Unknown key');
+        const iv = Buffer.from(encodedIv, 'base64url');
+        const ciphertext = Buffer.from(encodedCiphertext, 'base64url');
+        const authTag = Buffer.from(encodedAuthTag, 'base64url');
+        if (iv.length !== IV_BYTES || authTag.length !== AUTH_TAG_BYTES) throw new Error('Invalid envelope');
+
+        const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_BYTES });
+        decipher.setAAD(additionalAuthenticatedData(context));
+        decipher.setAuthTag(authTag);
+        return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+    } catch {
+        throw new Error('Unable to decrypt passenger data');
+    }
+}
+
+export function getPassengerDataRetentionDeadline(departureDate: Date): Date {
+    return new Date(departureDate.getTime() + RETENTION_DAYS * 24 * 60 * 60 * 1_000);
+}

--- a/lib/passengerDataRetention.ts
+++ b/lib/passengerDataRetention.ts
@@ -1,0 +1,29 @@
+import { prisma } from '@/lib/prisma';
+
+const purgeValues = (now: Date) => ({
+    dateOfBirthEncrypted: null,
+    passportNumberEncrypted: null,
+    sensitiveDataDeletedAt: now,
+});
+
+export async function purgeExpiredPassengerData(now = new Date()): Promise<number> {
+    const result = await prisma.passenger.updateMany({
+        where: {
+            sensitiveDataDeletedAt: null,
+            sensitiveDataExpiresAt: { lte: now },
+        },
+        data: purgeValues(now),
+    });
+    return result.count;
+}
+
+export async function purgePassengerDataForUser(userId: string, now = new Date()): Promise<number> {
+    const result = await prisma.passenger.updateMany({
+        where: {
+            booking: { userId },
+            sensitiveDataDeletedAt: null,
+        },
+        data: purgeValues(now),
+    });
+    return result.count;
+}

--- a/lib/passengerDataRotation.ts
+++ b/lib/passengerDataRotation.ts
@@ -1,0 +1,61 @@
+import { prisma } from '@/lib/prisma';
+import {
+    decryptPassengerData,
+    encryptPassengerData,
+    getConfiguredPassengerDataEncryptionKeys,
+} from '@/lib/passengerDataProtection';
+
+export async function rotatePassengerDataEncryptionBatch(batchSize = 100): Promise<number> {
+    const keyRing = getConfiguredPassengerDataEncryptionKeys();
+    const activePrefix = `v1:${keyRing.activeKeyId}:`;
+    const passengers = await prisma.passenger.findMany({
+        where: {
+            sensitiveDataDeletedAt: null,
+            dateOfBirthEncrypted: { not: null },
+            passportNumberEncrypted: { not: null },
+            OR: [
+                { dateOfBirthEncrypted: { not: { startsWith: activePrefix } } },
+                { passportNumberEncrypted: { not: { startsWith: activePrefix } } },
+            ],
+        },
+        select: {
+            id: true,
+            dateOfBirthEncrypted: true,
+            passportNumberEncrypted: true,
+        },
+        take: batchSize,
+        orderBy: { id: 'asc' },
+    });
+
+    const results = await prisma.$transaction(passengers.map(passenger => {
+        if (!passenger.dateOfBirthEncrypted || !passenger.passportNumberEncrypted) {
+            throw new Error('Passenger identity data is incomplete.');
+        }
+        const dateOfBirth = decryptPassengerData(passenger.dateOfBirthEncrypted, {
+            passengerId: passenger.id,
+            field: 'dateOfBirth',
+        }, keyRing);
+        const passportNumber = decryptPassengerData(passenger.passportNumberEncrypted, {
+            passengerId: passenger.id,
+            field: 'passportNumber',
+        }, keyRing);
+        return prisma.passenger.updateMany({
+            where: {
+                id: passenger.id,
+                sensitiveDataDeletedAt: null,
+            },
+            data: {
+                dateOfBirthEncrypted: encryptPassengerData(dateOfBirth, {
+                    passengerId: passenger.id,
+                    field: 'dateOfBirth',
+                }, keyRing),
+                passportNumberEncrypted: encryptPassengerData(passportNumber, {
+                    passengerId: passenger.id,
+                    field: 'passportNumber',
+                }, keyRing),
+            },
+        });
+    }));
+
+    return results.reduce((count, result) => count + result.count, 0);
+}

--- a/prisma/migrations/20260714010000_protect_passenger_data/migration.sql
+++ b/prisma/migrations/20260714010000_protect_passenger_data/migration.sql
@@ -1,0 +1,16 @@
+-- Existing rows belong to the pre-production demo dataset. Purge their
+-- plaintext identity fields during the migration rather than copying
+-- sensitive values without access to the runtime encryption key.
+ALTER TABLE "Passenger"
+    DROP COLUMN "dateOfBirth",
+    DROP COLUMN "passportNumber",
+    ADD COLUMN "dateOfBirthEncrypted" TEXT,
+    ADD COLUMN "passportNumberEncrypted" TEXT,
+    ADD COLUMN "sensitiveDataExpiresAt" TIMESTAMP(3),
+    ADD COLUMN "sensitiveDataDeletedAt" TIMESTAMP(3);
+
+UPDATE "Passenger"
+SET "sensitiveDataDeletedAt" = CURRENT_TIMESTAMP;
+
+CREATE INDEX "Passenger_sensitiveDataExpiresAt_idx"
+ON "Passenger"("sensitiveDataExpiresAt");

--- a/prisma/migrations/20260714011000_enforce_passenger_data_state/migration.sql
+++ b/prisma/migrations/20260714011000_enforce_passenger_data_state/migration.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "Passenger"
+ADD CONSTRAINT "Passenger_sensitive_data_state_check"
+CHECK (
+    (
+        "dateOfBirthEncrypted" IS NOT NULL
+        AND "passportNumberEncrypted" IS NOT NULL
+        AND "sensitiveDataExpiresAt" IS NOT NULL
+        AND "sensitiveDataDeletedAt" IS NULL
+    )
+    OR (
+        "dateOfBirthEncrypted" IS NULL
+        AND "passportNumberEncrypted" IS NULL
+        AND "sensitiveDataDeletedAt" IS NOT NULL
+    )
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,14 +111,16 @@ model Booking {
 }
 
 model Passenger {
-  id             String   @id @default(cuid())
-  firstName      String
-  lastName       String
-  dateOfBirth    DateTime
-  passportNumber String
-  gender         String
-  seatNumber     String
-  cabinClass     String
+  id                      String    @id @default(cuid())
+  firstName               String
+  lastName                String
+  dateOfBirthEncrypted    String?   @db.Text
+  passportNumberEncrypted String?   @db.Text
+  sensitiveDataExpiresAt  DateTime?
+  sensitiveDataDeletedAt  DateTime?
+  gender                  String
+  seatNumber              String
+  cabinClass              String
 
   bookingId Int
   booking   Booking @relation(fields: [bookingId], references: [id], onDelete: Cascade)
@@ -127,6 +129,7 @@ model Passenger {
   flight   Flight @relation(fields: [flightId], references: [id], onDelete: Cascade)
 
   @@unique([flightId, seatNumber])
+  @@index([sensitiveDataExpiresAt])
 }
 
 model Flight {

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -15,6 +15,7 @@ require_value() {
 require_value DATABASE_URL
 require_value NEXTAUTH_URL
 require_value NEXTAUTH_SECRET
+require_value PASSENGER_DATA_ENCRYPTION_KEYS
 require_value AUTH_TRUSTED_PROXY_HOPS
 require_value AUTH_EMAIL_FROM
 require_value AUTH_EMAIL_PROVIDER

--- a/scripts/verify-container-secrets.sh
+++ b/scripts/verify-container-secrets.sh
@@ -32,13 +32,13 @@ image_labels="$($container_runtime image inspect \
   --format '{{json .Config.Labels}}' "$image")"
 
 if printf '%s\n' "$image_environment" | \
-  grep -Eq '^(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET|AUTH_EMAIL_API_TOKEN)='; then
+  grep -Eq '^(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET|AUTH_EMAIL_API_TOKEN|PASSENGER_DATA_ENCRYPTION_KEYS)='; then
   echo "Sensitive runtime configuration key found in image environment." >&2
   exit 1
 fi
 
 if printf '%s\n' "$image_labels" | \
-  grep -Eq '"(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET|AUTH_EMAIL_API_TOKEN)"[[:space:]]*:'; then
+  grep -Eq '"(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET|AUTH_EMAIL_API_TOKEN|PASSENGER_DATA_ENCRYPTION_KEYS)"[[:space:]]*:'; then
   echo "Sensitive runtime configuration key found in image labels." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- encrypt passport numbers and dates of birth with versioned AES-256-GCM envelopes and authenticated passenger/field context
- restrict customer and staff passenger projections to non-sensitive manifest fields
- add 30-day post-departure retention deletion, immediate erasure support, and bounded active-key rotation
- migrate away from plaintext columns and enforce protected-or-deleted passenger state in PostgreSQL
- document the passenger-data policy and require the key ring in local, CI, and container environments
- add database, security, component, responsive, and real-passenger browser regression coverage

## Why

This completes the passenger-data protection subitem of roadmap item P0.5. Passport numbers and birth dates previously lived in plaintext and routine profile/admin queries loaded them even when the UI did not need them.

Existing pre-production demo identity values are deliberately purged by the migration instead of being copied through migration tooling without the runtime encryption key. Booking and seat history remain intact.

## Validation

- Jest: 45 suites, 333 tests passed
- Playwright: 14 Chromium journeys passed without retries
- TypeScript and Prisma validation/generation passed
- all 14 migrations applied both to the live development database and a fresh temporary database
- production Next.js build passed
- ESLint passed with 0 errors (8 pre-existing warnings)
- Docker image built; 17 layers passed the secret scan
- final UI review and code review approved with no findings

## Deployment note

Set `PASSENGER_DATA_ENCRYPTION_KEYS` to a comma-separated `key-id:base64-key` key ring before deployment. The first 32-byte key is active; retain older keys until live ciphertext and required backups have rotated or aged out.
