### PR TITLE
Require staff MFA for admin access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ NEXTAUTH_SECRET=
 # retain older keys while rotating existing ciphertext. Generate a key with:
 # openssl rand -base64 32
 PASSENGER_DATA_ENCRYPTION_KEYS=
+# Separate key ring used only to encrypt staff authenticator secrets.
+STAFF_MFA_ENCRYPTION_KEYS=
 # Direct local development does not trust forwarded addresses. The bundled
 # Docker proxy supplies its own production-safe value to the app container.
 AUTH_TRUSTED_PROXY_HOPS=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       NEXTAUTH_SECRET: ci-only-nextauth-secret-at-least-32-characters
       NEXTAUTH_URL: http://localhost:3000
       PASSENGER_DATA_ENCRYPTION_KEYS: ci-v1:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+      STAFF_MFA_ENCRYPTION_KEYS: ci-v1:YWJjZGVmMDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODk=
       AUTH_TRUSTED_PROXY_HOPS: 1
       AUTH_EMAIL_FROM: Mona Airways <no-reply@localhost>
       AUTH_EMAIL_PROVIDER: mailpit

--- a/README.md
+++ b/README.md
@@ -32,13 +32,19 @@ cp .env.example .env
 Replace `NEXTAUTH_SECRET` with a securely generated value of at least 32
 characters. Generate the active passenger-data key with
 `openssl rand -base64 32` and set it as
-`PASSENGER_DATA_ENCRYPTION_KEYS=local-v1:<generated-value>`. Local
+`PASSENGER_DATA_ENCRYPTION_KEYS=local-v1:<generated-value>`. Generate a
+different 32-byte key for staff authenticator secrets and set it as
+`STAFF_MFA_ENCRYPTION_KEYS=local-v1:<different-generated-value>`. Local
 non-container development may leave
 `AUTH_TRUSTED_PROXY_HOPS` at `0`. The recommended Compose deployment supplies
 its own safe value; other deployments must set it to the exact number of
 trusted right-most proxy entries. Deployed environments must inject all secret
 configuration at runtime; never bake `.env` into an image. See
 [SECURITY.md](SECURITY.md) for rotation and incident guidance.
+
+Staff accounts must enroll a TOTP authenticator before using any admin page or
+mutation. See [docs/STAFF_ACCOUNT_POLICY.md](docs/STAFF_ACCOUNT_POLICY.md) for
+the enrollment, reset, and key-rotation procedures.
 
 ### Using Docker (Recommended)
 

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -104,7 +104,7 @@ Acceptance criteria:
 - [x] Use generic account-existence responses where appropriate.
 - [x] Define encryption, access, retention, redaction, and deletion rules for
   passport numbers and dates of birth.
-- [ ] Add stronger protection for staff accounts.
+- [x] Add stronger protection for staff accounts.
 
 Acceptance criteria:
 
@@ -486,3 +486,4 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-12 | P0.4 | Complete | #38 | Made server fares and inventory authoritative, removed fake payment identifiers, and added idempotent, concurrency-tested booking persistence. |
 | 2026-07-12 | P0.5 | In progress | #39 + #40 | Canonicalized email identity, added database-backed registration and login throttles, and implemented generic verified-email activation and password recovery journeys. Staff protection and passenger-data rules remain. |
 | 2026-07-14 | P0.5 | In progress | #42 | Added authenticated encryption, safe customer/staff projections, automated retention deletion and key rotation, and a tested passenger-data policy. Stronger staff protection remains. |
+| 2026-07-14 | P0.5 | Complete | #43 | Required TOTP for staff accounts, limited first-time enrollment sessions, encrypted authenticator secrets, replay-resistant codes, and an eight-hour staff authentication window. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,10 @@
   keep it separate from the database, and follow the access, rotation,
   retention, and deletion rules in
   [docs/PASSENGER_DATA_POLICY.md](docs/PASSENGER_DATA_POLICY.md).
+- Generate each `STAFF_MFA_ENCRYPTION_KEYS` entry as a separate random 32-byte
+  key and keep it outside the database. Staff authenticator enrollment,
+  session limits, replay protection, reset, and rotation requirements are in
+  [docs/STAFF_ACCOUNT_POLICY.md](docs/STAFF_ACCOUNT_POLICY.md).
 - Set `AUTH_EMAIL_PROVIDER=postmark`, configure `AUTH_EMAIL_FROM` and
   `AUTH_EMAIL_API_URL=https://api.postmarkapp.com/email`, and inject
   `AUTH_EMAIL_API_TOKEN` through the secret manager for deployed transactional
@@ -44,6 +48,11 @@ configured deployment.
 Authentication throttles store only keyed digests of email/IP identifiers.
 Every throttle operation deletes a bounded batch of expired rows so attacker-
 controlled identifiers are not retained indefinitely.
+
+Every `ADMIN` session requires a password and a verified TOTP code. A new staff
+member receives only an enrollment session until setup is confirmed; admin
+pages and mutations independently reject that limited session. Staff proof
+expires after eight hours, and a TOTP time step can be consumed only once.
 
 Email verification and password reset tokens are random, single-use, scoped
 to one purpose, and stored only as SHA-256 digests. Verification tokens expire

--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -127,8 +127,16 @@ describe('saveCityGuideAction authorization', () => {
         expect(mockSaveCityGuide).not.toHaveBeenCalled();
     });
 
+    it('rejects an admin whose staff factor has not been verified', async () => {
+        mockedGetServerSession.mockResolvedValue({
+            user: { role: 'ADMIN', staffMfaVerified: false },
+        });
+        await expect(saveCityGuideAction(sampleGuide)).rejects.toThrow('Unauthorized');
+        expect(mockSaveCityGuide).not.toHaveBeenCalled();
+    });
+
     it('allows an admin user and saves the guide', async () => {
-        mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+        mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
         mockSaveCityGuide.mockResolvedValue({ ...sampleGuide, id: 1 });
 
         const result = await saveCityGuideAction(sampleGuide);
@@ -138,7 +146,7 @@ describe('saveCityGuideAction authorization', () => {
     });
 
     it('normalizes guide text before saving', async () => {
-        mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+        mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
         mockSaveCityGuide.mockResolvedValue({ id: 1 });
 
         await saveCityGuideAction({
@@ -170,7 +178,7 @@ describe('deleteCityGuideAction authorization and execution', () => {
     });
 
     it('allows an admin user and deletes the guide', async () => {
-        mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+        mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
         mockedCityGuideDelete.mockResolvedValue({});
 
         await deleteCityGuideAction(1);
@@ -520,7 +528,7 @@ describe('cancelBookingAction', () => {
     });
 
     it('allows an admin to cancel any booking', async () => {
-        mockedGetServerSession.mockResolvedValue({ user: { id: 'admin-123', role: 'ADMIN' } });
+        mockedGetServerSession.mockResolvedValue({ user: { id: 'admin-123', role: 'ADMIN', staffMfaVerified: true } });
         mockedBookingFindUnique.mockResolvedValue({
             id: 1,
             userId: 'some-user',
@@ -700,7 +708,7 @@ describe('deleteReviewAction', () => {
     });
 
     it('allows an admin to delete any review', async () => {
-        mockedGetServerSession.mockResolvedValue({ user: { id: 'admin-123', role: 'ADMIN' } });
+        mockedGetServerSession.mockResolvedValue({ user: { id: 'admin-123', role: 'ADMIN', staffMfaVerified: true } });
         mockedReviewFindUnique.mockResolvedValue({ id: 'rev-123', userId: 'some-user' });
         mockedReviewDelete.mockResolvedValue({ id: 'rev-123' });
 
@@ -745,7 +753,7 @@ describe('admin flight schedule actions', () => {
         });
 
         it('rejects an explicitly empty seat pattern', async () => {
-            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
 
             await expect(saveFlightScheduleAction({
                 ...sampleScheduleInput,
@@ -762,7 +770,7 @@ describe('admin flight schedule actions', () => {
         });
 
         it('allows admin to create a new flight schedule and generates flights', async () => {
-            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
             mockedFlightScheduleCreate.mockResolvedValue({
                 id: 1,
                 ...sampleScheduleInput,
@@ -807,7 +815,7 @@ describe('admin flight schedule actions', () => {
         });
 
         it('normalizes schedule identifiers before persistence', async () => {
-            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
             mockedFlightScheduleCreate.mockResolvedValue({ id: 1, daysOfWeek: [] });
 
             await saveFlightScheduleAction({
@@ -821,7 +829,7 @@ describe('admin flight schedule actions', () => {
         });
 
         it('allows admin to update an existing flight schedule', async () => {
-            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
             const scheduleWithId = { id: 5, ...sampleScheduleInput };
             mockedFlightScheduleUpdate.mockResolvedValue(scheduleWithId);
             mockedFlightFindFirst.mockResolvedValue({}); // existing instances, skips creating new ones
@@ -851,7 +859,7 @@ describe('admin flight schedule actions', () => {
         });
 
         it('allows admin to delete schedule', async () => {
-            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
             mockedFlightScheduleDelete.mockResolvedValue({});
 
             await deleteFlightScheduleAction(12);
@@ -869,7 +877,7 @@ describe('admin flight schedule actions', () => {
         });
 
         it('allows admin to update status and creates flight update notifications for affected users', async () => {
-            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+            mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
             mockedFlightUpdate.mockResolvedValue({
                 id: 99,
                 airline: 'Gemini Airways',
@@ -1003,7 +1011,7 @@ describe('admin flight schedule actions', () => {
             });
 
             it('generates flight instances and updates existing ones', async () => {
-                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
 
                 mockedFlightScheduleFindUnique.mockResolvedValue({
                     id: 1,
@@ -1050,7 +1058,7 @@ describe('admin flight schedule actions', () => {
             });
 
             it('rejects invalid seating configuration inputs', async () => {
-                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
 
                 mockedFlightScheduleFindUnique.mockResolvedValue({
                     id: 1,
@@ -1113,7 +1121,7 @@ describe('admin flight schedule actions', () => {
             });
 
             it('normalizes seat patterns before persisting occurrences', async () => {
-                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
                 mockedFlightScheduleFindUnique.mockResolvedValue({
                     id: 1,
                     flightNumber: 'AA101',
@@ -1137,7 +1145,7 @@ describe('admin flight schedule actions', () => {
             });
 
             it('reports existing occurrences as updated', async () => {
-                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
                 mockedFlightScheduleFindUnique.mockResolvedValue({
                     id: 1,
                     flightNumber: 'AA101',
@@ -1168,7 +1176,7 @@ describe('admin flight schedule actions', () => {
             });
 
             it('applies the requested layout after a concurrent occurrence create', async () => {
-                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
                 mockedFlightScheduleFindUnique.mockResolvedValue({
                     id: 1,
                     flightNumber: 'AA101',
@@ -1210,7 +1218,7 @@ describe('admin flight schedule actions', () => {
             });
 
             it('rejects malformed or excessive occurrence date ranges', async () => {
-                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
                 mockedFlightScheduleFindUnique.mockResolvedValue({ id: 1, daysOfWeek: [] });
 
                 await expect(
@@ -1222,7 +1230,7 @@ describe('admin flight schedule actions', () => {
             });
 
             it('does not invalidate seats already assigned to passengers', async () => {
-                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
                 mockedFlightScheduleFindUnique.mockResolvedValue({
                     id: 1,
                     flightNumber: 'AA101',
@@ -1264,7 +1272,7 @@ describe('admin flight schedule actions', () => {
             });
 
             it('does not move an occupied seat across cabin boundaries', async () => {
-                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN' } });
+                mockedGetServerSession.mockResolvedValue({ user: { role: 'ADMIN', staffMfaVerified: true } });
                 mockedFlightScheduleFindUnique.mockResolvedValue({
                     id: 1,
                     flightNumber: 'AA101',

--- a/__tests__/app/staffMfaActions.test.ts
+++ b/__tests__/app/staffMfaActions.test.ts
@@ -1,0 +1,115 @@
+/** @jest-environment node */
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }));
+jest.mock('@/lib/auth', () => ({ authOptions: {} }));
+jest.mock('@/lib/prisma', () => ({
+    prisma: {
+        user: {
+            findUnique: jest.fn(),
+            updateMany: jest.fn(),
+        },
+    },
+}));
+jest.mock('@/lib/staffMfa', () => ({
+    createStaffMfaOtpAuthUri: jest.fn(() => 'otpauth://totp/Mona'),
+    decryptStaffMfaSecret: jest.fn(() => 'SECRET'),
+    encryptStaffMfaSecret: jest.fn(() => 'encrypted-secret'),
+    generateStaffMfaSecret: jest.fn(() => 'SECRET'),
+    verifyStaffTotpCode: jest.fn(() => 123),
+}));
+
+import { getServerSession } from 'next-auth';
+import { prisma } from '@/lib/prisma';
+import { verifyStaffTotpCode } from '@/lib/staffMfa';
+import {
+    beginStaffMfaEnrollment,
+    confirmStaffMfaEnrollment,
+} from '@/app/staff/mfa/actions';
+
+const session = {
+    user: {
+        id: 'admin-1',
+        email: 'admin@example.com',
+        role: 'ADMIN',
+        staffMfaVerified: false,
+        staffMfaEnrollmentRequired: true,
+    },
+};
+
+describe('staff MFA enrollment actions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getServerSession as jest.Mock).mockResolvedValue(session);
+        (prisma.user.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+        (verifyStaffTotpCode as jest.Mock).mockReturnValue(123);
+    });
+
+    it('rejects non-admin and already-verified sessions', async () => {
+        (getServerSession as jest.Mock).mockResolvedValueOnce({
+            user: { ...session.user, role: 'USER' },
+        });
+        await expect(beginStaffMfaEnrollment()).rejects.toThrow(
+            'Staff MFA enrollment is not available.'
+        );
+
+        (getServerSession as jest.Mock).mockResolvedValueOnce({
+            user: { ...session.user, staffMfaVerified: true },
+        });
+        await expect(beginStaffMfaEnrollment()).rejects.toThrow(
+            'Staff MFA enrollment is not available.'
+        );
+    });
+
+    it('stores an encrypted pending secret and returns authenticator setup data', async () => {
+        (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+            email: 'admin@example.com',
+            staffMfaEnrolledAt: null,
+        });
+
+        await expect(beginStaffMfaEnrollment()).resolves.toEqual({
+            manualKey: 'SECRET',
+            otpAuthUri: 'otpauth://totp/Mona',
+        });
+        expect(prisma.user.updateMany).toHaveBeenCalledWith({
+            where: { id: 'admin-1', staffMfaEnrolledAt: null },
+            data: {
+                staffMfaSecretEncrypted: 'encrypted-secret',
+                staffMfaLastUsedStep: null,
+            },
+        });
+    });
+
+    it('rejects an invalid authenticator code without enrolling the account', async () => {
+        (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+            staffMfaSecretEncrypted: 'encrypted-secret',
+            staffMfaEnrolledAt: null,
+        });
+        (verifyStaffTotpCode as jest.Mock).mockReturnValue(null);
+
+        await expect(confirmStaffMfaEnrollment('123456')).resolves.toEqual({
+            ok: false,
+            error: 'That code is invalid or expired.',
+        });
+        expect(prisma.user.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('enrolls atomically and invalidates the limited setup session', async () => {
+        (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+            staffMfaSecretEncrypted: 'encrypted-secret',
+            staffMfaEnrolledAt: null,
+        });
+
+        await expect(confirmStaffMfaEnrollment('123456')).resolves.toEqual({ ok: true });
+        expect(prisma.user.updateMany).toHaveBeenCalledWith({
+            where: {
+                id: 'admin-1',
+                staffMfaSecretEncrypted: 'encrypted-secret',
+                staffMfaEnrolledAt: null,
+            },
+            data: {
+                staffMfaEnrolledAt: expect.any(Date),
+                staffMfaLastUsedStep: 123,
+                authVersion: { increment: 1 },
+            },
+        });
+    });
+});

--- a/__tests__/components/StaffMfaEnrollment.test.tsx
+++ b/__tests__/components/StaffMfaEnrollment.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { signOut } from 'next-auth/react';
+import StaffMfaEnrollment from '@/app/staff/mfa/StaffMfaEnrollment';
+import {
+    beginStaffMfaEnrollment,
+    confirmStaffMfaEnrollment,
+} from '@/app/staff/mfa/actions';
+
+jest.mock('next-auth/react', () => ({ signOut: jest.fn() }));
+jest.mock('@/app/staff/mfa/actions', () => ({
+    beginStaffMfaEnrollment: jest.fn(),
+    confirmStaffMfaEnrollment: jest.fn(),
+}));
+
+describe('StaffMfaEnrollment', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (beginStaffMfaEnrollment as jest.Mock).mockResolvedValue({
+            manualKey: 'JBSWY3DPEHPK3PXP',
+            otpAuthUri: 'otpauth://totp/Mona',
+        });
+        (confirmStaffMfaEnrollment as jest.Mock).mockResolvedValue({ ok: true });
+    });
+
+    it('guides a staff member through setup and signs out the limited session', async () => {
+        render(<StaffMfaEnrollment />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Set up authenticator' }));
+        expect(await screen.findByTestId('staff-mfa-manual-key')).toHaveTextContent(
+            'JBSWY3DPEHPK3PXP'
+        );
+        expect(screen.getByRole('link', { name: 'Open in authenticator app' }))
+            .toHaveAttribute('href', 'otpauth://totp/Mona');
+
+        fireEvent.change(screen.getByLabelText('Six-digit security code'), {
+            target: { value: '12a3456' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Verify and finish setup' }));
+
+        await waitFor(() => expect(confirmStaffMfaEnrollment).toHaveBeenCalledWith('123456'));
+        expect(signOut).toHaveBeenCalledWith({ callbackUrl: '/login?staffMfa=enrolled' });
+    });
+
+    it('keeps setup disabled while the server action is pending', async () => {
+        let resolveSetup!: (value: { manualKey: string; otpAuthUri: string }) => void;
+        (beginStaffMfaEnrollment as jest.Mock).mockReturnValue(new Promise(resolve => {
+            resolveSetup = resolve;
+        }));
+        render(<StaffMfaEnrollment />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Set up authenticator' }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Starting setup…' })).toBeDisabled();
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Starting setup…' }));
+        expect(beginStaffMfaEnrollment).toHaveBeenCalledTimes(1);
+
+        resolveSetup({
+            manualKey: 'JBSWY3DPEHPK3PXP',
+            otpAuthUri: 'otpauth://totp/Mona',
+        });
+        expect(await screen.findByTestId('staff-mfa-manual-key')).toBeInTheDocument();
+    });
+
+    it('keeps the setup visible and announces an invalid code', async () => {
+        (confirmStaffMfaEnrollment as jest.Mock).mockResolvedValue({
+            ok: false,
+            error: 'That code is invalid or expired.',
+        });
+        render(<StaffMfaEnrollment />);
+        fireEvent.click(screen.getByRole('button', { name: 'Set up authenticator' }));
+        await screen.findByTestId('staff-mfa-manual-key');
+
+        fireEvent.change(screen.getByLabelText('Six-digit security code'), {
+            target: { value: '123456' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Verify and finish setup' }));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent('That code is invalid or expired.');
+        expect(signOut).not.toHaveBeenCalled();
+    });
+});

--- a/__tests__/components/UserAuthForm.test.tsx
+++ b/__tests__/components/UserAuthForm.test.tsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import UserAuthForm from '@/app/login/components/user-auth-form';
-import { signIn } from 'next-auth/react';
+import { getSession, signIn } from 'next-auth/react';
 
-jest.mock('next-auth/react', () => ({ signIn: jest.fn() }));
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+
+jest.mock('next-auth/react', () => ({ getSession: jest.fn(), signIn: jest.fn() }));
 jest.mock('next/navigation', () => ({
-    useRouter: () => ({ push: jest.fn(), refresh: jest.fn() })
+    useRouter: () => ({ push: mockPush, refresh: mockRefresh })
 }));
 
 const contrastRatio = (foreground: string, background: string) => {
@@ -26,6 +29,7 @@ describe('UserAuthForm registration errors', () => {
         jest.restoreAllMocks();
         jest.clearAllMocks();
         global.fetch = jest.fn();
+        (getSession as jest.Mock).mockResolvedValue({ user: { role: 'USER' } });
     });
 
     it('keeps accepted and pending status text above WCAG AA contrast', () => {
@@ -74,6 +78,55 @@ describe('UserAuthForm registration errors', () => {
         const alert = await screen.findByRole('alert');
         expect(alert).toHaveTextContent('Invalid email or password.');
         await waitFor(() => expect(alert).toHaveFocus());
+    });
+
+    it('routes regular users to the home page after login', async () => {
+        (signIn as jest.Mock).mockResolvedValue({ ok: true });
+        render(<UserAuthForm type="login" />);
+
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'user@example.com' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Sign In with Email' }));
+
+        await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/'));
+        expect(mockRefresh).toHaveBeenCalled();
+    });
+
+    it('continues first-time staff through the enrollment gate', async () => {
+        (signIn as jest.Mock).mockResolvedValue({ ok: true });
+        (getSession as jest.Mock).mockResolvedValue({
+            user: { role: 'ADMIN', staffMfaVerified: false, staffMfaEnrollmentRequired: true },
+        });
+        render(<UserAuthForm type="login" />);
+
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'admin@example.com' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Sign In with Email' }));
+
+        await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/staff/mfa'));
+        expect(mockRefresh).toHaveBeenCalled();
+    });
+
+    it('submits the optional staff code and routes verified staff to admin', async () => {
+        (signIn as jest.Mock).mockResolvedValue({ ok: true });
+        (getSession as jest.Mock).mockResolvedValue({
+            user: { role: 'ADMIN', staffMfaVerified: true, staffMfaEnrollmentRequired: false },
+        });
+        render(<UserAuthForm type="login" />);
+
+        fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'admin@example.com' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+        fireEvent.change(screen.getByLabelText(/Staff security code/), { target: { value: '123456' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Sign In with Email' }));
+
+        await waitFor(() => expect(signIn).toHaveBeenCalledWith('credentials', {
+            redirect: false,
+            email: 'admin@example.com',
+            password: 'password123',
+            staffCode: '123456',
+        }));
+        expect(mockPush).toHaveBeenCalledWith('/admin');
+        expect(mockRefresh).toHaveBeenCalled();
     });
 
     it('shows the same neutral state after every accepted registration without signing in', async () => {

--- a/__tests__/components/titlebar.test.tsx
+++ b/__tests__/components/titlebar.test.tsx
@@ -33,7 +33,7 @@ const mockMarkAllNotificationsAsRead = markAllNotificationsAsReadAction as jest.
 describe('TitleBar', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        mockGetUserNotifications.mockResolvedValue([]);
+        mockGetUserNotifications.mockReturnValue(new Promise(() => { }));
     });
 
     it('renders the correct title when pathname is /book', () => {
@@ -56,12 +56,25 @@ describe('TitleBar', () => {
 
     it('renders the admin view when pathname is /admin/travelguide', () => {
         (usePathname as jest.Mock).mockReturnValue('/admin/travelguide');
-        (require('next-auth/react').useSession as jest.Mock).mockReturnValue({ data: { user: { role: 'ADMIN' } } });
+        (require('next-auth/react').useSession as jest.Mock).mockReturnValue({
+            data: { user: { role: 'ADMIN', staffMfaVerified: true } }
+        });
 
         render(<TitleBar />);
 
         expect(screen.getByText('Admin')).toBeInTheDocument();
         expect(screen.queryByText('Book Flight')).not.toBeInTheDocument();
+    });
+
+    it('does not expose the admin navigation before staff MFA is verified', () => {
+        (usePathname as jest.Mock).mockReturnValue('/book');
+        (require('next-auth/react').useSession as jest.Mock).mockReturnValue({
+            data: { user: { role: 'ADMIN', staffMfaVerified: false } }
+        });
+
+        render(<TitleBar />);
+
+        expect(screen.queryByText('Admin')).not.toBeInTheDocument();
     });
 
     it('calls signOut when the Sign Out button is clicked', () => {
@@ -131,7 +144,9 @@ describe('TitleBar', () => {
         expect(notifItem).toBeInTheDocument();
         fireEvent.click(notifItem!);
 
-        expect(mockMarkNotificationAsRead).toHaveBeenCalledWith('n1');
+        await waitFor(() => {
+            expect(mockMarkNotificationAsRead).toHaveBeenCalledWith('n1');
+        });
     });
 
     it('handles mark all as read action', async () => {
@@ -154,6 +169,8 @@ describe('TitleBar', () => {
         });
 
         fireEvent.click(screen.getByRole('button', { name: 'Mark all read' }));
-        expect(mockMarkAllNotificationsAsRead).toHaveBeenCalled();
+        await waitFor(() => {
+            expect(mockMarkAllNotificationsAsRead).toHaveBeenCalled();
+        });
     });
 });

--- a/__tests__/instrumentation.test.ts
+++ b/__tests__/instrumentation.test.ts
@@ -19,6 +19,7 @@ describe('server instrumentation', () => {
             NEXTAUTH_URL: 'http://localhost:3000',
             NEXTAUTH_SECRET: 'a-secure-test-secret-that-is-at-least-32-characters',
             PASSENGER_DATA_ENCRYPTION_KEYS: 'test-v1:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+            STAFF_MFA_ENCRYPTION_KEYS: 'test-v1:YWJjZGVmMDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODk=',
             AUTH_EMAIL_FROM: 'Mona Airways <no-reply@localhost>',
             AUTH_EMAIL_PROVIDER: 'mailpit',
             AUTH_EMAIL_API_URL: 'http://localhost:8025/api/v1/send',

--- a/__tests__/lib/auth.test.ts
+++ b/__tests__/lib/auth.test.ts
@@ -14,10 +14,15 @@ jest.mock('@/lib/authRateLimit', () => ({
     consumeAuthRateLimit: jest.fn(),
     clearAuthRateLimit: jest.fn(),
 }));
+jest.mock('@/lib/staffMfa', () => ({
+    STAFF_MFA_SESSION_MAX_AGE_MS: 8 * 60 * 60 * 1_000,
+    verifyAndConsumeStaffTotp: jest.fn(),
+}));
 
 // Imported after mocks so the mocked deps are wired in.
 import { authOptions } from '@/lib/auth';
 import { clearAuthRateLimit, consumeAuthRateLimit } from '@/lib/authRateLimit';
+import { verifyAndConsumeStaffTotp } from '@/lib/staffMfa';
 
 const authorize = (authOptions.providers[0] as any).authorize as (
     credentials: Record<string, string> | undefined,
@@ -28,12 +33,14 @@ const mockedPrisma = prisma as unknown as { user: { findUnique: jest.Mock } };
 const mockedCompare = bcrypt.compare as unknown as jest.Mock;
 const mockedConsumeRateLimit = consumeAuthRateLimit as jest.Mock;
 const mockedClearRateLimit = clearAuthRateLimit as jest.Mock;
+const mockedVerifyStaffTotp = verifyAndConsumeStaffTotp as jest.Mock;
 
 describe('authOptions credential authorize', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         delete process.env.AUTH_TRUSTED_PROXY_HOPS;
         mockedConsumeRateLimit.mockResolvedValue({ allowed: true, retryAfterSeconds: 0 });
+        mockedVerifyStaffTotp.mockResolvedValue(false);
     });
 
     it('normalizes the email before rate limiting and account lookup', async () => {
@@ -138,6 +145,52 @@ describe('authOptions credential authorize', () => {
         expect(mockedClearRateLimit).toHaveBeenCalledWith('login-email', 'a@b.com');
     });
 
+    it('creates only a restricted enrollment session for staff without TOTP', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue({
+            id: 'admin-1', email: 'admin@example.com', name: 'Admin', image: null,
+            password: 'real-hash', role: 'ADMIN', authVersion: 3,
+            emailVerified: new Date(), staffMfaSecretEncrypted: null, staffMfaEnrolledAt: null,
+        });
+        mockedCompare.mockResolvedValue(true);
+
+        const result = await authorize({ email: 'admin@example.com', password: 'correct-horse' });
+
+        expect(result).toMatchObject({
+            role: 'ADMIN',
+            staffMfaVerified: false,
+            staffMfaEnrollmentRequired: true,
+        });
+    });
+
+    it('requires and consumes a valid TOTP code for enrolled staff', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue({
+            id: 'admin-1', email: 'admin@example.com', name: 'Admin', image: null,
+            password: 'real-hash', role: 'ADMIN', authVersion: 3,
+            emailVerified: new Date(), staffMfaSecretEncrypted: 'v1:active:iv:data:tag',
+            staffMfaEnrolledAt: new Date(),
+        });
+        mockedCompare.mockResolvedValue(true);
+
+        await expect(authorize({
+            email: 'admin@example.com', password: 'correct-horse', staffCode: '123456'
+        })).rejects.toThrow('Invalid email or password');
+
+        mockedVerifyStaffTotp.mockResolvedValue(true);
+        const result = await authorize({
+            email: 'admin@example.com', password: 'correct-horse', staffCode: '123456'
+        });
+        expect(mockedVerifyStaffTotp).toHaveBeenCalledWith(
+            'admin-1',
+            'v1:active:iv:data:tag',
+            '123456'
+        );
+        expect(result).toMatchObject({
+            staffMfaVerified: true,
+            staffMfaEnrollmentRequired: false,
+            staffMfaVerifiedAt: expect.any(Number),
+        });
+    });
+
     it('throws error when email or password is missing', async () => {
         const err1 = await authorize(undefined).catch((e) => e);
         const err2 = await authorize({ email: 'a@b.com' } as any).catch((e) => e);
@@ -159,9 +212,16 @@ describe('authOptions jwt/session callbacks', () => {
     it('jwt callback copies id, role, and auth version from user onto the token', async () => {
         const token = await jwt({
             token: {},
-            user: { id: 'u1', role: 'ADMIN', authVersion: 2 },
+            user: {
+                id: 'u1', role: 'ADMIN', authVersion: 2,
+                staffMfaVerified: true, staffMfaEnrollmentRequired: false,
+                staffMfaVerifiedAt: 1_000,
+            },
         });
-        expect(token).toMatchObject({ id: 'u1', role: 'ADMIN', authVersion: 2 });
+        expect(token).toMatchObject({
+            id: 'u1', role: 'ADMIN', authVersion: 2,
+            staffMfaVerified: true, staffMfaVerifiedAt: 1_000,
+        });
     });
 
     it('jwt callback refreshes account state and invalidates older auth versions', async () => {
@@ -182,12 +242,60 @@ describe('authOptions jwt/session callbacks', () => {
         expect(stale).toMatchObject({ invalidated: true });
     });
 
+    it('invalidates verified staff proof after eight hours', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue({
+            role: 'ADMIN',
+            authVersion: 1,
+            emailVerified: new Date(),
+            staffMfaEnrolledAt: new Date(),
+        });
+
+        const result = await jwt({
+            token: {
+                id: 'admin-1',
+                role: 'ADMIN',
+                authVersion: 1,
+                staffMfaVerified: true,
+                staffMfaVerifiedAt: Date.now() - (8 * 60 * 60 * 1_000) - 1,
+            },
+        });
+
+        expect(result).toMatchObject({ invalidated: true });
+    });
+
+    it('invalidates a verified staff session when MFA enrollment is removed', async () => {
+        mockedPrisma.user.findUnique.mockResolvedValue({
+            role: 'ADMIN',
+            authVersion: 1,
+            emailVerified: new Date(),
+            staffMfaEnrolledAt: null,
+        });
+
+        const result = await jwt({
+            token: {
+                id: 'admin-1',
+                role: 'ADMIN',
+                authVersion: 1,
+                staffMfaVerified: true,
+                staffMfaVerifiedAt: Date.now(),
+            },
+        });
+
+        expect(result).toMatchObject({ invalidated: true });
+    });
+
     it('session callback exposes id and role on session.user', async () => {
         const result = await session({
             session: { user: { email: 'a@b.com' } },
-            token: { id: 'u1', role: 'ADMIN' },
+            token: {
+                id: 'u1', role: 'ADMIN',
+                staffMfaVerified: true, staffMfaEnrollmentRequired: false,
+            },
         });
-        expect(result.user).toMatchObject({ id: 'u1', role: 'ADMIN', email: 'a@b.com' });
+        expect(result.user).toMatchObject({
+            id: 'u1', role: 'ADMIN', email: 'a@b.com',
+            staffMfaVerified: true, staffMfaEnrollmentRequired: false,
+        });
     });
 
     it('session callback returns no session for an invalidated token', async () => {

--- a/__tests__/lib/env.test.ts
+++ b/__tests__/lib/env.test.ts
@@ -8,6 +8,7 @@ const validEnvironment = {
     AUTH_EMAIL_PROVIDER: 'mailpit',
     AUTH_EMAIL_API_URL: 'http://localhost:8025/api/v1/send',
     PASSENGER_DATA_ENCRYPTION_KEYS: `local:${Buffer.from('0123456789abcdef0123456789abcdef').toString('base64')}`,
+    STAFF_MFA_ENCRYPTION_KEYS: `local:${Buffer.from('abcdef0123456789abcdef0123456789').toString('base64')}`,
 };
 
 describe('validateServerEnvironment', () => {
@@ -17,7 +18,8 @@ describe('validateServerEnvironment', () => {
 
     it.each([
         'DATABASE_URL', 'NEXTAUTH_URL', 'NEXTAUTH_SECRET', 'AUTH_EMAIL_FROM',
-        'AUTH_EMAIL_PROVIDER', 'AUTH_EMAIL_API_URL', 'PASSENGER_DATA_ENCRYPTION_KEYS'
+        'AUTH_EMAIL_PROVIDER', 'AUTH_EMAIL_API_URL', 'PASSENGER_DATA_ENCRYPTION_KEYS',
+        'STAFF_MFA_ENCRYPTION_KEYS'
     ] as const)(
         'rejects a missing %s',
         (key) => {
@@ -35,6 +37,13 @@ describe('validateServerEnvironment', () => {
             ...validEnvironment,
             PASSENGER_DATA_ENCRYPTION_KEYS: 'local:not-a-32-byte-key',
         })).toThrow('PASSENGER_DATA_ENCRYPTION_KEYS');
+    });
+
+    it('rejects malformed staff MFA encryption keys', () => {
+        expect(() => validateServerEnvironment({
+            ...validEnvironment,
+            STAFF_MFA_ENCRYPTION_KEYS: 'local:not-a-32-byte-key',
+        })).toThrow('STAFF_MFA_ENCRYPTION_KEYS');
     });
 
     it('rejects a non-PostgreSQL database URL', () => {

--- a/__tests__/lib/staffAuthorization.test.ts
+++ b/__tests__/lib/staffAuthorization.test.ts
@@ -1,0 +1,11 @@
+/** @jest-environment node */
+import { hasVerifiedStaffAccess } from '@/lib/staffAuthorization';
+
+describe('staff authorization', () => {
+    it('requires both the ADMIN role and a verified second factor', () => {
+        expect(hasVerifiedStaffAccess(null)).toBe(false);
+        expect(hasVerifiedStaffAccess({ user: { role: 'USER', staffMfaVerified: true } } as never)).toBe(false);
+        expect(hasVerifiedStaffAccess({ user: { role: 'ADMIN', staffMfaVerified: false } } as never)).toBe(false);
+        expect(hasVerifiedStaffAccess({ user: { role: 'ADMIN', staffMfaVerified: true } } as never)).toBe(true);
+    });
+});

--- a/__tests__/lib/staffMfa.test.ts
+++ b/__tests__/lib/staffMfa.test.ts
@@ -1,0 +1,108 @@
+/** @jest-environment node */
+jest.mock('@/lib/prisma', () => ({
+    prisma: { user: { updateMany: jest.fn() } },
+}));
+
+import {
+    createStaffTotpCode,
+    decryptStaffMfaSecret,
+    encryptStaffMfaSecret,
+    generateStaffMfaSecret,
+    parseStaffMfaEncryptionKeys,
+    verifyAndConsumeStaffTotp,
+    verifyStaffTotpCode,
+} from '@/lib/staffMfa';
+import { prisma } from '@/lib/prisma';
+
+const ACTIVE_KEY = Buffer.from('0123456789abcdef0123456789abcdef').toString('base64');
+const OLD_KEY = Buffer.from('abcdef0123456789abcdef0123456789').toString('base64');
+
+describe('staff TOTP protection', () => {
+    const originalEnvironment = process.env;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        process.env = {
+            ...originalEnvironment,
+            STAFF_MFA_ENCRYPTION_KEYS: `active:${ACTIVE_KEY}`,
+        };
+    });
+
+    afterAll(() => {
+        process.env = originalEnvironment;
+    });
+
+    it('matches the RFC 6238 SHA-1 test vector', () => {
+        const secret = 'GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ';
+
+        expect(createStaffTotpCode(secret, new Date(59_000), 8)).toBe('94287082');
+    });
+
+    it('accepts a current or adjacent TOTP step and rejects malformed codes', () => {
+        const secret = generateStaffMfaSecret();
+        const now = new Date('2026-07-14T18:00:00.000Z');
+        const code = createStaffTotpCode(secret, now);
+
+        expect(verifyStaffTotpCode(secret, code, now)).toBe(Math.floor(now.getTime() / 30_000));
+        expect(verifyStaffTotpCode(secret, code, new Date(now.getTime() + 30_000))).not.toBeNull();
+        expect(verifyStaffTotpCode(secret, '12345', now)).toBeNull();
+        expect(verifyStaffTotpCode(secret, 'abcdef', now)).toBeNull();
+    });
+
+    it('encrypts authenticator secrets with user-bound authenticated context', () => {
+        const keys = parseStaffMfaEncryptionKeys(`active:${ACTIVE_KEY}`);
+        const secret = generateStaffMfaSecret();
+        const encrypted = encryptStaffMfaSecret(secret, 'admin-1', keys);
+
+        expect(encrypted).toMatch(/^v1:active:/);
+        expect(encrypted).not.toContain(secret);
+        expect(decryptStaffMfaSecret(encrypted, 'admin-1', keys)).toBe(secret);
+        expect(() => decryptStaffMfaSecret(encrypted, 'admin-2', keys))
+            .toThrow('Unable to decrypt staff MFA secret');
+    });
+
+    it('reads retained keys while writing with the active key', () => {
+        const oldOnly = parseStaffMfaEncryptionKeys(`old:${OLD_KEY}`);
+        const rotated = parseStaffMfaEncryptionKeys(`active:${ACTIVE_KEY},old:${OLD_KEY}`);
+        const secret = generateStaffMfaSecret();
+        const oldCiphertext = encryptStaffMfaSecret(secret, 'admin-1', oldOnly);
+
+        expect(decryptStaffMfaSecret(oldCiphertext, 'admin-1', rotated)).toBe(secret);
+        expect(encryptStaffMfaSecret(secret, 'admin-1', rotated)).toMatch(/^v1:active:/);
+    });
+
+    it.each([
+        '',
+        'missing-separator',
+        `bad id:${ACTIVE_KEY}`,
+        `wildcard_key:${ACTIVE_KEY}`,
+        'short:c2hvcnQ=',
+        `duplicate:${ACTIVE_KEY},duplicate:${OLD_KEY}`,
+    ])('rejects an unsafe MFA key ring: %s', value => {
+        expect(() => parseStaffMfaEncryptionKeys(value)).toThrow();
+    });
+
+    it('atomically consumes a valid step and refuses a replay', async () => {
+        const now = new Date();
+        const step = Math.floor(now.getTime() / 30_000);
+        const secret = generateStaffMfaSecret();
+        const encrypted = encryptStaffMfaSecret(secret, 'admin-1');
+        const code = createStaffTotpCode(secret, now);
+        const updateMany = prisma.user.updateMany as jest.Mock;
+        updateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 0 });
+
+        await expect(verifyAndConsumeStaffTotp('admin-1', encrypted, code)).resolves.toBe(true);
+        expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({
+            where: expect.objectContaining({
+                id: 'admin-1',
+                OR: [
+                    { staffMfaLastUsedStep: null },
+                    { staffMfaLastUsedStep: { lt: step } },
+                ],
+            }),
+            data: expect.objectContaining({ staffMfaLastUsedStep: step }),
+        }));
+
+        await expect(verifyAndConsumeStaffTotp('admin-1', encrypted, code)).resolves.toBe(false);
+    });
+});

--- a/__tests__/security/containerEntrypoint.test.ts
+++ b/__tests__/security/containerEntrypoint.test.ts
@@ -8,6 +8,7 @@ const validEnvironment: NodeJS.ProcessEnv = {
     NEXTAUTH_URL: 'http://localhost:3000',
     NEXTAUTH_SECRET: 'a-secure-test-secret-that-is-at-least-32-characters',
     PASSENGER_DATA_ENCRYPTION_KEYS: 'test-v1:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=',
+    STAFF_MFA_ENCRYPTION_KEYS: 'test-v1:YWJjZGVmMDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODk=',
     AUTH_TRUSTED_PROXY_HOPS: '1',
     AUTH_EMAIL_FROM: 'Mona Airways <no-reply@localhost>',
     AUTH_EMAIL_PROVIDER: 'mailpit',
@@ -29,7 +30,7 @@ describe('container entrypoint', () => {
     it.each([
         'DATABASE_URL', 'NEXTAUTH_URL', 'NEXTAUTH_SECRET', 'AUTH_TRUSTED_PROXY_HOPS',
         'AUTH_EMAIL_FROM', 'AUTH_EMAIL_PROVIDER', 'AUTH_EMAIL_API_URL',
-        'PASSENGER_DATA_ENCRYPTION_KEYS'
+        'PASSENGER_DATA_ENCRYPTION_KEYS', 'STAFF_MFA_ENCRYPTION_KEYS'
     ] as const)(
         'fails before startup when %s is missing',
         (key) => {

--- a/__tests__/security/containerSecrets.test.ts
+++ b/__tests__/security/containerSecrets.test.ts
@@ -45,6 +45,7 @@ describe('container secret protection', () => {
         expect(composeFile).toContain('NEXTAUTH_URL: ${NEXTAUTH_URL:?NEXTAUTH_URL is required}');
         expect(composeFile).toContain('NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}');
         expect(composeFile).toContain('PASSENGER_DATA_ENCRYPTION_KEYS: ${PASSENGER_DATA_ENCRYPTION_KEYS:?PASSENGER_DATA_ENCRYPTION_KEYS is required}');
+        expect(composeFile).toContain('STAFF_MFA_ENCRYPTION_KEYS: ${STAFF_MFA_ENCRYPTION_KEYS:?STAFF_MFA_ENCRYPTION_KEYS is required}');
         expect(appService).toContain('AUTH_TRUSTED_PROXY_HOPS: "1"');
         expect(appService).toContain('AUTH_EMAIL_FROM:');
         expect(appService).toContain('AUTH_EMAIL_PROVIDER: mailpit');
@@ -68,6 +69,8 @@ describe('container secret protection', () => {
         expect(composeFile).toContain('- "3000:8080"');
         expect(composeFile).toContain('./deploy/nginx.conf:/etc/nginx/nginx.conf:ro');
         expect(proxyConfiguration).toContain('proxy_pass http://app:3000;');
+        expect(proxyConfiguration).toContain('proxy_set_header Host $host;');
+        expect(proxyConfiguration).toContain('proxy_set_header X-Forwarded-Host $http_host;');
         expect(proxyConfiguration).toContain('proxy_set_header X-Forwarded-For $remote_addr;');
         expect(proxyConfiguration).not.toContain('$proxy_add_x_forwarded_for');
         expect(proxyConfiguration).toContain('log_format no_query');
@@ -101,6 +104,7 @@ describe('container secret protection', () => {
         expect(verificationScript).toContain('SECRET_SCAN_SENTINEL');
         expect(verificationScript).toContain('AUTH_EMAIL_API_TOKEN');
         expect(verificationScript).toContain('PASSENGER_DATA_ENCRYPTION_KEYS');
+        expect(verificationScript).toContain('STAFF_MFA_ENCRYPTION_KEYS');
     });
 
     it('provides safe configuration and secret-rotation guidance', () => {
@@ -113,6 +117,8 @@ describe('container secret protection', () => {
         expect(exampleEnvironment.match(/^NEXTAUTH_SECRET=(.*)$/m)?.[1]).toBe('');
         expect(exampleEnvironment).toContain('PASSENGER_DATA_ENCRYPTION_KEYS=');
         expect(exampleEnvironment.match(/^PASSENGER_DATA_ENCRYPTION_KEYS=(.*)$/m)?.[1]).toBe('');
+        expect(exampleEnvironment).toContain('STAFF_MFA_ENCRYPTION_KEYS=');
+        expect(exampleEnvironment.match(/^STAFF_MFA_ENCRYPTION_KEYS=(.*)$/m)?.[1]).toBe('');
         expect(exampleEnvironment).toContain('AUTH_TRUSTED_PROXY_HOPS=0');
         expect(exampleEnvironment).toContain('AUTH_EMAIL_FROM=');
         expect(exampleEnvironment).toContain('AUTH_EMAIL_PROVIDER=mailpit');

--- a/__tests__/security/staffMfaSchema.test.ts
+++ b/__tests__/security/staffMfaSchema.test.ts
@@ -1,0 +1,28 @@
+/** @jest-environment node */
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('staff MFA database state', () => {
+    const root = process.cwd();
+    const schema = fs.readFileSync(path.join(root, 'prisma/schema.prisma'), 'utf8');
+    const migrationPath = path.join(
+        root,
+        'prisma/migrations/20260714020000_add_staff_mfa/migration.sql'
+    );
+
+    it('stores only encrypted TOTP material and replay state', () => {
+        expect(schema).toContain('staffMfaSecretEncrypted String?');
+        expect(schema).toContain('staffMfaEnrolledAt      DateTime?');
+        expect(schema).toContain('staffMfaLastUsedStep    Int?');
+        expect(schema).not.toMatch(/staffMfaSecret\s+String/);
+    });
+
+    it('ships a migration with consistent enrollment-state constraints', () => {
+        expect(fs.existsSync(migrationPath)).toBe(true);
+        const migration = fs.readFileSync(migrationPath, 'utf8');
+        expect(migration).toContain('staffMfaSecretEncrypted');
+        expect(migration).toContain('staffMfaEnrolledAt');
+        expect(migration).toContain('staffMfaLastUsedStep');
+        expect(migration).toContain('User_staff_mfa_state_check');
+    });
+});

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -7,6 +7,7 @@ import FlightScheduleService from '@/lib/FlightScheduleService';
 import CityGuide from '@/lib/types/CityGuide';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { hasVerifiedStaffAccess } from '@/lib/staffAuthorization';
 import { prisma } from '@/lib/prisma';
 import { assertSeatAvailableForCabin, validateSeatingLayout } from '@/lib/seatLayout';
 import { lockFlightForUpdate } from '@/lib/flightLock';
@@ -34,7 +35,7 @@ const flightBookingService = new FlightBookingService();
 
 export async function saveCityGuideAction(cityGuide: CityGuide) {
     const session = await getServerSession(authOptions);
-    if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
+    if (!hasVerifiedStaffAccess(session)) throw new Error("Unauthorized");
 
     const parsed = parseActionInput(cityGuideSchema, cityGuide);
     if (!parsed.ok) return parsed;
@@ -46,7 +47,7 @@ export async function saveCityGuideAction(cityGuide: CityGuide) {
 
 export async function deleteCityGuideAction(cityGuideId: number) {
     const session = await getServerSession(authOptions);
-    if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
+    if (!hasVerifiedStaffAccess(session)) throw new Error("Unauthorized");
 
     const parsed = parseActionInput(numericIdSchema, cityGuideId);
     if (!parsed.ok) return parsed;
@@ -220,7 +221,7 @@ export async function cancelBookingAction(bookingId: number) {
     });
     if (!booking) throw new Error("Booking not found");
 
-    if (session.user.role !== 'ADMIN' && booking.userId !== userId) {
+    if (!hasVerifiedStaffAccess(session) && booking.userId !== userId) {
         throw new Error("Unauthorized");
     }
 
@@ -292,7 +293,7 @@ export async function changeBookingSeatsAction(
     });
     if (!booking) throw new Error("Booking not found");
 
-    if (session.user.role !== 'ADMIN' && booking.userId !== userId) {
+    if (!hasVerifiedStaffAccess(session) && booking.userId !== userId) {
         throw new Error("Unauthorized");
     }
 
@@ -377,7 +378,7 @@ export async function deleteReviewAction(reviewId: string) {
     });
     if (!review) throw new Error("Review not found");
 
-    if (session.user.role !== 'ADMIN' && review.userId !== userId) {
+    if (!hasVerifiedStaffAccess(session) && review.userId !== userId) {
         throw new Error("Unauthorized");
     }
 
@@ -408,7 +409,7 @@ export async function saveFlightScheduleAction(data: {
     seatPattern?: string | null;
 }) {
     const session = await getServerSession(authOptions);
-    if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
+    if (!hasVerifiedStaffAccess(session)) throw new Error("Unauthorized");
     const parsed = parseActionInput(scheduleSchema, data);
     if (!parsed.ok) return parsed;
     data = parsed.data as typeof data;
@@ -569,7 +570,7 @@ export async function generateFlightOccurrencesAction(
     }
 ) {
     const session = await getServerSession(authOptions);
-    if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
+    if (!hasVerifiedStaffAccess(session)) throw new Error("Unauthorized");
     const parsed = parseActionInput(occurrenceRequestSchema, {
         scheduleId,
         startDate: startDateStr,
@@ -733,7 +734,7 @@ export async function generateFlightOccurrencesAction(
 
 export async function deleteFlightScheduleAction(scheduleId: number) {
     const session = await getServerSession(authOptions);
-    if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
+    if (!hasVerifiedStaffAccess(session)) throw new Error("Unauthorized");
 
     const parsed = parseActionInput(numericIdSchema, scheduleId);
     if (!parsed.ok) return parsed;
@@ -749,7 +750,7 @@ export async function deleteFlightScheduleAction(scheduleId: number) {
 
 export async function updateFlightStatusAction(flightId: number, status: 'ON_TIME' | 'DELAYED' | 'CANCELLED') {
     const session = await getServerSession(authOptions);
-    if (session?.user?.role !== 'ADMIN') throw new Error("Unauthorized");
+    if (!hasVerifiedStaffAccess(session)) throw new Error("Unauthorized");
 
     const parsedId = parseActionInput(numericIdSchema, flightId);
     if (!parsedId.ok) return parsedId;

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { hasVerifiedStaffAccess } from '@/lib/staffAuthorization';
+
+export default async function AdminLayout({ children }: { children: React.ReactNode }) {
+    const session = await getServerSession(authOptions);
+    if (!hasVerifiedStaffAccess(session)) {
+        if (session?.user?.role === 'ADMIN' && session.user.staffMfaEnrollmentRequired) {
+            redirect('/staff/mfa');
+        }
+        redirect('/login');
+    }
+    return children;
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -13,7 +13,15 @@ export default async function AdminDashboard() {
     const recentBookings = await prisma.booking.findMany({
         take: 5,
         orderBy: { createdAt: 'desc' },
-        include: { user: true, flight: true }
+        include: {
+            user: {
+                select: {
+                    name: true,
+                    email: true,
+                },
+            },
+            flight: true,
+        },
     });
 
     return (

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -7,7 +7,13 @@ export const dynamic = 'force-dynamic';
 export default async function AdminUsersPage() {
     const users = await prisma.user.findMany({
         orderBy: { email: 'asc' },
-        include: { _count: { select: { bookings: true, reviews: true, favorites: true } } }
+        select: {
+            id: true,
+            name: true,
+            email: true,
+            role: true,
+            _count: { select: { bookings: true, reviews: true, favorites: true } }
+        }
     });
 
     return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -113,6 +113,88 @@ header nav ul li.selected a {
               radial-gradient(circle at 90% 80%, rgba(139, 92, 246, 0.1) 0%, rgba(13, 12, 20, 0) 50%);
 }
 
+.staff-mfa-page {
+  justify-content: center;
+}
+
+.staff-mfa-card {
+  width: min(100%, 34rem);
+  padding: clamp(1.5rem, 5vw, 2.5rem);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+}
+
+.staff-mfa-card h1 {
+  margin-top: 0;
+  font-size: clamp(1.75rem, 5vw, 2.4rem);
+}
+
+.staff-mfa-card p {
+  color: #d4d4d8;
+  line-height: 1.6;
+}
+
+.staff-mfa-card [role="alert"] {
+  margin: 1rem 0;
+  padding: 0.75rem;
+  color: #fecaca;
+  background: rgba(127, 29, 29, 0.35);
+  border: 1px solid #ef4444;
+  border-radius: 0.5rem;
+}
+
+.staff-mfa-setup {
+  display: grid;
+  gap: 1rem;
+}
+
+.staff-mfa-setup code {
+  display: block;
+  padding: 0.85rem;
+  overflow-wrap: anywhere;
+  color: #fff;
+  background: #18181b;
+  border: 1px solid #52525b;
+  border-radius: 0.5rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.08em;
+}
+
+.staff-mfa-setup a {
+  color: #c4b5fd;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.staff-mfa-setup label {
+  font-weight: 600;
+}
+
+.staff-mfa-setup input {
+  width: 100%;
+  min-height: 3rem;
+  padding: 0.75rem;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid #71717a;
+  border-radius: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.staff-mfa-card button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+}
+
+.staff-mfa-card .secondary-button {
+  background: transparent;
+  border: 1px solid #8b5cf6;
+  box-shadow: none;
+}
+
 .home {
   background-image: linear-gradient(180deg, rgba(13, 12, 20, 0.5) 0%, #0d0c14 100%), url('/img/gemini-background.jpg');
   background-size: cover;

--- a/app/login/components/user-auth-form.tsx
+++ b/app/login/components/user-auth-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { signIn } from "next-auth/react";
+import { getSession, signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
 interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -39,6 +39,7 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
         const formData = new FormData(event.currentTarget);
         const email = String(formData.get('email') ?? '');
         const password = String(formData.get('password') ?? '');
+        const staffCode = String(formData.get('staffCode') ?? '');
         const name = String(formData.get('name') ?? '');
 
         try {
@@ -72,12 +73,18 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                 redirect: false,
                 email,
                 password,
+                staffCode,
             });
 
             if (result?.error) {
                 showFormError('Invalid email or password.');
             } else {
-                router.push("/");
+                const session = await getSession();
+                if (session?.user?.role === 'ADMIN') {
+                    router.push(session.user.staffMfaVerified ? "/admin" : "/staff/mfa");
+                } else {
+                    router.push("/");
+                }
                 router.refresh();
             }
         } catch {
@@ -165,6 +172,34 @@ export default function UserAuthForm({ className, type, ...props }: UserAuthForm
                             </p>
                         )}
                     </div>
+                    {type === 'login' && (
+                        <div className="grid gap-1">
+                            <label htmlFor="staffCode" style={{ fontSize: '0.8rem', color: '#d4d4d8' }}>
+                                Staff security code <span style={{ color: '#71717a' }}>(staff only)</span>
+                            </label>
+                            <input
+                                id="staffCode"
+                                name="staffCode"
+                                placeholder="123456"
+                                type="text"
+                                inputMode="numeric"
+                                autoComplete="one-time-code"
+                                pattern="[0-9]{6}"
+                                maxLength={6}
+                                disabled={isLoading}
+                                style={{
+                                    display: "flex",
+                                    height: "2.5rem",
+                                    width: "100%",
+                                    borderRadius: "0.375rem",
+                                    border: "1px solid #e4e4e7",
+                                    backgroundColor: "transparent",
+                                    padding: "0.5rem 0.75rem",
+                                    fontSize: "0.875rem",
+                                }}
+                            />
+                        </div>
+                    )}
                     <div className="grid gap-1">
                         <label className="sr-only" htmlFor="password">
                             Password

--- a/app/staff/mfa/StaffMfaEnrollment.tsx
+++ b/app/staff/mfa/StaffMfaEnrollment.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React, { useRef, useState } from 'react';
+import { signOut } from 'next-auth/react';
+import {
+    beginStaffMfaEnrollment,
+    confirmStaffMfaEnrollment,
+} from './actions';
+
+export default function StaffMfaEnrollment() {
+    const [setup, setSetup] = useState<{ manualKey: string; otpAuthUri: string } | null>(null);
+    const [code, setCode] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [pending, setPending] = useState(false);
+    const errorRef = useRef<HTMLDivElement>(null);
+
+    const begin = async () => {
+        if (pending) return;
+        setPending(true);
+        setError(null);
+        try {
+            setSetup(await beginStaffMfaEnrollment());
+        } catch {
+            setError('Unable to start authenticator setup. Please try again.');
+            window.setTimeout(() => errorRef.current?.focus(), 0);
+        } finally {
+            setPending(false);
+        }
+    };
+
+    const confirm = async () => {
+        if (pending) return;
+        setPending(true);
+        setError(null);
+        try {
+            const result = await confirmStaffMfaEnrollment(code);
+            if (!result.ok) {
+                setError(result.error);
+                window.setTimeout(() => errorRef.current?.focus(), 0);
+                return;
+            }
+            await signOut({ callbackUrl: '/login?staffMfa=enrolled' });
+        } catch {
+            setError('Unable to verify setup. Please try again.');
+            window.setTimeout(() => errorRef.current?.focus(), 0);
+        } finally {
+            setPending(false);
+        }
+    };
+
+    return (
+        <section className="staff-mfa-card" aria-labelledby="staff-mfa-title">
+            <h1 id="staff-mfa-title">Protect your staff account</h1>
+            <p>
+                Staff access requires a time-based security code in addition to your password.
+                Add this account to an authenticator app before opening the admin dashboard.
+            </p>
+
+            {error && <div ref={errorRef} role="alert" tabIndex={-1}>{error}</div>}
+
+            {!setup ? (
+                <button type="button" onClick={begin} disabled={pending}>
+                    {pending ? 'Starting setup…' : 'Set up authenticator'}
+                </button>
+            ) : (
+                <div className="staff-mfa-setup">
+                    <p><strong>Manual setup key</strong></p>
+                    <code data-testid="staff-mfa-manual-key">{setup.manualKey}</code>
+                    <a href={setup.otpAuthUri}>Open in authenticator app</a>
+                    <label htmlFor="staff-mfa-code">Six-digit security code</label>
+                    <input
+                        id="staff-mfa-code"
+                        name="staffMfaCode"
+                        value={code}
+                        onChange={event => setCode(event.target.value.replace(/\D/g, '').slice(0, 6))}
+                        inputMode="numeric"
+                        autoComplete="one-time-code"
+                        pattern="[0-9]{6}"
+                        maxLength={6}
+                        disabled={pending}
+                    />
+                    <button type="button" onClick={confirm} disabled={pending || code.length !== 6}>
+                        {pending ? 'Verifying…' : 'Verify and finish setup'}
+                    </button>
+                    <button type="button" onClick={begin} disabled={pending} className="secondary-button">
+                        Generate a new key
+                    </button>
+                </div>
+            )}
+        </section>
+    );
+}

--- a/app/staff/mfa/actions.ts
+++ b/app/staff/mfa/actions.ts
@@ -1,0 +1,90 @@
+"use server";
+
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import {
+    createStaffMfaOtpAuthUri,
+    decryptStaffMfaSecret,
+    encryptStaffMfaSecret,
+    generateStaffMfaSecret,
+    verifyStaffTotpCode,
+} from '@/lib/staffMfa';
+
+async function requireEnrollmentSession() {
+    const session = await getServerSession(authOptions);
+    if (session?.user?.role !== 'ADMIN' || session.user.staffMfaVerified) {
+        throw new Error('Staff MFA enrollment is not available.');
+    }
+    return session;
+}
+
+export async function beginStaffMfaEnrollment() {
+    const session = await requireEnrollmentSession();
+    const user = await prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: { email: true, staffMfaEnrolledAt: true },
+    });
+    if (!user?.email || user.staffMfaEnrolledAt) {
+        throw new Error('Staff MFA enrollment is not available.');
+    }
+
+    const secret = generateStaffMfaSecret();
+    const encryptedSecret = encryptStaffMfaSecret(secret, session.user.id);
+    const updated = await prisma.user.updateMany({
+        where: { id: session.user.id, staffMfaEnrolledAt: null },
+        data: {
+            staffMfaSecretEncrypted: encryptedSecret,
+            staffMfaLastUsedStep: null,
+        },
+    });
+    if (updated.count !== 1) throw new Error('Staff MFA enrollment is not available.');
+
+    return {
+        manualKey: secret,
+        otpAuthUri: createStaffMfaOtpAuthUri(secret, user.email),
+    };
+}
+
+export async function confirmStaffMfaEnrollment(code: string) {
+    const session = await requireEnrollmentSession();
+    if (!/^\d{6}$/.test(code.trim())) {
+        return { ok: false as const, error: 'Enter the six-digit code from your authenticator app.' };
+    }
+
+    const user = await prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: { staffMfaSecretEncrypted: true, staffMfaEnrolledAt: true },
+    });
+    if (!user?.staffMfaSecretEncrypted || user.staffMfaEnrolledAt) {
+        return { ok: false as const, error: 'Start setup again and enter a new code.' };
+    }
+
+    let secret: string;
+    try {
+        secret = decryptStaffMfaSecret(user.staffMfaSecretEncrypted, session.user.id);
+    } catch {
+        return { ok: false as const, error: 'Start setup again and enter a new code.' };
+    }
+    const matchedStep = verifyStaffTotpCode(secret, code);
+    if (matchedStep === null) {
+        return { ok: false as const, error: 'That code is invalid or expired.' };
+    }
+
+    const updated = await prisma.user.updateMany({
+        where: {
+            id: session.user.id,
+            staffMfaSecretEncrypted: user.staffMfaSecretEncrypted,
+            staffMfaEnrolledAt: null,
+        },
+        data: {
+            staffMfaEnrolledAt: new Date(),
+            staffMfaLastUsedStep: matchedStep,
+            authVersion: { increment: 1 },
+        },
+    });
+    if (updated.count !== 1) {
+        return { ok: false as const, error: 'Start setup again and enter a new code.' };
+    }
+    return { ok: true as const };
+}

--- a/app/staff/mfa/page.tsx
+++ b/app/staff/mfa/page.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import StaffMfaEnrollment from './StaffMfaEnrollment';
+
+export const dynamic = 'force-dynamic';
+
+export default async function StaffMfaPage() {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) redirect('/login');
+    if (session.user.role !== 'ADMIN') redirect('/');
+    if (session.user.staffMfaVerified) redirect('/admin');
+    if (!session.user.staffMfaEnrollmentRequired) redirect('/login');
+
+    return (
+        <main className="page-container staff-mfa-page">
+            <StaffMfaEnrollment />
+        </main>
+    );
+}

--- a/app/travelguide/page.tsx
+++ b/app/travelguide/page.tsx
@@ -9,7 +9,18 @@ export default async function TravelGuidePage() {
     const userId = session?.user?.id ?? null;
 
     const cities = await prisma.cityGuide.findMany({
-        include: { reviews: { include: { user: true } } }
+        include: {
+            reviews: {
+                include: {
+                    user: {
+                        select: {
+                            name: true,
+                            image: true,
+                        },
+                    },
+                },
+            },
+        },
     });
 
     let initialFavorites: number[] = [];

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Link from 'next/link';
 
 const Footer: React.FC = () => {
     return (
@@ -11,7 +10,6 @@ const Footer: React.FC = () => {
                 <li>Contact Us</li>
                 <li>FAQ</li>
                 <li>About us</li>
-                <li><Link href="/admin/travelguide">Admin</Link></li>
             </ul>
             </div>
 

--- a/components/ui/titlebar.tsx
+++ b/components/ui/titlebar.tsx
@@ -38,7 +38,7 @@ const TitleBar: React.FC = () => {
 
     const pageTitle = pageTitles[pathname] || '';
     const userAvatar = session?.user?.image || "/img/my-profile-photo.jpg";
-    const isAdmin = session?.user?.role === 'ADMIN';
+    const isAdmin = session?.user?.role === 'ADMIN' && session.user.staffMfaVerified;
 
     const fetchNotifications = useCallback(async () => {
         if (session?.user) {

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -22,6 +22,7 @@ http {
             proxy_pass http://app:3000;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       NEXTAUTH_URL: ${NEXTAUTH_URL:?NEXTAUTH_URL is required}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}
       PASSENGER_DATA_ENCRYPTION_KEYS: ${PASSENGER_DATA_ENCRYPTION_KEYS:?PASSENGER_DATA_ENCRYPTION_KEYS is required}
+      STAFF_MFA_ENCRYPTION_KEYS: ${STAFF_MFA_ENCRYPTION_KEYS:?STAFF_MFA_ENCRYPTION_KEYS is required}
       # The bundled proxy below is the single trusted right-most proxy.
       AUTH_TRUSTED_PROXY_HOPS: "1"
       AUTH_EMAIL_FROM: "${AUTH_EMAIL_FROM:-Mona Airways <no-reply@localhost>}"

--- a/docs/STAFF_ACCOUNT_POLICY.md
+++ b/docs/STAFF_ACCOUNT_POLICY.md
@@ -1,0 +1,72 @@
+# Staff account protection policy
+
+## Access requirements
+
+Every account with the `ADMIN` role must authenticate with both its password
+and a six-digit time-based one-time password (TOTP). Password-only staff
+sessions may access only the authenticator enrollment flow. Admin pages,
+navigation, and server mutations require a session whose staff factor was
+verified.
+
+Staff authentication proof has a maximum lifetime of eight hours. The user
+must sign in again with both factors after that window. Each accepted TOTP time
+step is recorded atomically and cannot be replayed, including by a concurrent
+request.
+
+TOTP improves resistance to password theft but is not phishing-resistant.
+Phishing-resistant authenticators, scoped staff permissions, and additional
+confirmation for privileged operations remain part of the P4.3 roadmap item.
+
+## Enrollment
+
+1. Promote the verified account to `ADMIN` through an authorized operational
+   process.
+2. The staff member signs in with their password and is redirected to the
+   enrollment page.
+3. They generate a setup key, add it to an authenticator app, and confirm a
+   current code.
+4. Confirmation records the enrollment timestamp and increments
+   `authVersion`, invalidating the limited enrollment session.
+5. They sign in again with their password and a current code before receiving
+   admin access.
+
+The setup secret is encrypted before database storage, even while enrollment
+is pending. Do not transmit or record the manual setup key in tickets, chat,
+logs, analytics, or screenshots.
+
+## Secret storage and rotation
+
+`STAFF_MFA_ENCRYPTION_KEYS` is a comma-separated key ring in
+`key-id:base64-key` form. Each key must decode to exactly 32 random bytes. The
+first entry is active for writes; retained entries decrypt older ciphertext.
+Use a key ring that is separate from `NEXTAUTH_SECRET`, passenger-data keys,
+database credentials, and other application secrets.
+
+To rotate the encryption key:
+
+1. Generate a random 32-byte key with `openssl rand -base64 32`.
+2. Add it as the first entry with a new key ID while retaining the previous
+   entries.
+3. Deploy the new key ring. Successful staff sign-ins re-encrypt their secret
+   with the active key.
+4. Confirm that no stored staff secret uses the retired key ID before removing
+   that key from every deployment.
+
+Losing every key that can decrypt a staff secret requires MFA reset for the
+affected accounts.
+
+## Reset and recovery
+
+There is intentionally no self-service staff-factor reset. An authorized
+operator must verify the staff member through the organization's documented
+identity process, record who approved and performed the reset, then atomically:
+
+- clear `staffMfaSecretEncrypted`, `staffMfaEnrolledAt`, and
+  `staffMfaLastUsedStep`; and
+- increment `authVersion` to invalidate existing sessions.
+
+The staff member then repeats enrollment. Password reset does not clear the
+staff factor. Do not bypass the second factor or temporarily downgrade an
+account as a recovery shortcut. If immediate access is required during an
+incident, use a separately governed break-glass account and review its activity
+afterward.

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -3,6 +3,14 @@ import { prisma } from '../lib/prisma';
 import FlightBookingService from '../lib/FlightBookingService';
 import { updateFlightSeatingLayout } from '../lib/FlightSeatLayoutService';
 import { createVerifiedAccount, registerAndSignIn, signInWithCredentials } from './helpers/auth';
+import { createStaffTotpCode } from '../lib/staffMfa';
+
+async function waitForStableTotpWindow() {
+  const remainder = Date.now() % 30_000;
+  if (remainder > 24_000) {
+    await new Promise(resolve => setTimeout(resolve, 31_000 - remainder));
+  }
+}
 
 test.describe('Admin Control Journey', () => {
   const adminEmail = `admin-${Date.now()}@example.com`;
@@ -54,10 +62,24 @@ test.describe('Admin Control Journey', () => {
       data: { role: 'ADMIN' }
     });
 
-    await signInWithCredentials(page, { email: adminEmail, password });
+    await signInWithCredentials(page, { email: adminEmail, password }, '/staff/mfa');
+
+    await page.getByRole('button', { name: 'Set up authenticator' }).click();
+    const secret = (await page.getByTestId('staff-mfa-manual-key').textContent())!.trim();
+    await waitForStableTotpWindow();
+    const enrollmentTime = new Date();
+    await page.getByLabel('Six-digit security code')
+      .fill(createStaffTotpCode(secret, new Date(enrollmentTime.getTime() - 30_000)));
+    await page.getByRole('button', { name: 'Verify and finish setup' }).click();
+    await expect(page).toHaveURL(/\/login\?staffMfa=enrolled/);
+
+    await signInWithCredentials(page, {
+      email: adminEmail,
+      password,
+      staffCode: createStaffTotpCode(secret),
+    }, '/admin');
 
     // Access admin dashboard
-    await page.goto('/admin');
     await expect(page.locator('h1:has-text("Admin Control Center")')).toBeVisible();
 
     // Go to Flight Manager

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,10 @@
+import { loadEnvConfig } from '@next/env';
+import { prisma } from '../lib/prisma';
+
+async function clearE2eAuthRateLimits() {
+  loadEnvConfig(process.cwd());
+  await prisma.authRateLimit.deleteMany();
+  await prisma.$disconnect();
+}
+
+export default clearE2eAuthRateLimits;

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,10 @@
+import { loadEnvConfig } from '@next/env';
+import { prisma } from '../lib/prisma';
+
+async function clearE2eAuthRateLimits() {
+  loadEnvConfig(process.cwd());
+  await prisma.authRateLimit.deleteMany();
+  await prisma.$disconnect();
+}
+
+export default clearE2eAuthRateLimits;

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -20,13 +20,15 @@ export async function createVerifiedAccount(
 
 export async function signInWithCredentials(
   page: Page,
-  account: { email: string; password: string }
+  account: { email: string; password: string; staffCode?: string },
+  expectedPath = '/',
 ) {
   await page.goto('/login');
   await page.fill('#email', account.email);
   await page.fill('#password', account.password);
+  if (account.staffCode) await page.fill('#staffCode', account.staffCode);
   await page.click('button:has-text("Sign In with Email")');
-  await expect(page).toHaveURL('/');
+  await expect(page).toHaveURL(expectedPath);
 }
 
 export async function registerAndSignIn(

--- a/e2e/travelguide.spec.ts
+++ b/e2e/travelguide.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { registerAndSignIn } from './helpers/auth';
+import { prisma } from '../lib/prisma';
 
 test.describe('Travel Guide Journey', () => {
   const uniqueEmail = `guidetest-${Date.now()}@example.com`;
@@ -45,6 +46,22 @@ test.describe('Travel Guide Journey', () => {
     // Expect the review text to appear in the reviews list
     const newReviewItem = activeSidebar.locator('li', { hasText: reviewText });
     await expect(newReviewItem).toBeVisible();
+
+    const reviewer = await prisma.user.update({
+      where: { email: uniqueEmail },
+      data: { staffMfaSecretEncrypted: 'staff-mfa-secret-sentinel' },
+      select: {
+        password: true,
+        staffMfaSecretEncrypted: true,
+      },
+    });
+    const publicResponse = await page.request.get('/travelguide');
+    expect(publicResponse.ok()).toBe(true);
+    const publicResponseBody = await publicResponse.text();
+    expect(publicResponseBody).not.toContain(reviewer.password!);
+    expect(publicResponseBody).not.toContain(reviewer.staffMfaSecretEncrypted!);
+    expect(publicResponseBody).not.toContain('staffMfaSecretEncrypted');
+    expect(publicResponseBody).not.toContain('staffMfaLastUsedStep');
 
     // Toggle favorite state
     const favoriteBtn = activeSidebar.locator('button:has-text("Favorite")');

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,6 +9,10 @@ import {
     getTrustedClientAddressFromHeaders,
     hasTrustedProxyConfiguration
 } from '@/lib/clientAddress';
+import {
+    STAFF_MFA_SESSION_MAX_AGE_MS,
+    verifyAndConsumeStaffTotp,
+} from '@/lib/staffMfa';
 
 // A valid bcrypt hash of a throwaway value, used only to equalize response
 // timing when no matching user exists (anti-enumeration). It is never a real
@@ -25,6 +29,7 @@ export const authOptions: NextAuthOptions = {
             credentials: {
                 email: { label: 'Email', type: 'email', placeholder: 'user@example.com' },
                 password: { label: 'Password', type: 'password' },
+                staffCode: { label: 'Staff security code', type: 'text' },
             },
             async authorize(credentials, request) {
                 // Single generic message for every failure mode so the response
@@ -64,6 +69,26 @@ export const authOptions: NextAuthOptions = {
                     throw new Error(INVALID);
                 }
 
+                let staffMfaVerified = false;
+                let staffMfaEnrollmentRequired = false;
+                let staffMfaVerifiedAt: number | undefined;
+                if (user.role === 'ADMIN') {
+                    if (!user.staffMfaSecretEncrypted || !user.staffMfaEnrolledAt) {
+                        staffMfaEnrollmentRequired = true;
+                    } else {
+                        staffMfaVerified = Boolean(
+                            credentials.staffCode
+                            && await verifyAndConsumeStaffTotp(
+                                user.id,
+                                user.staffMfaSecretEncrypted,
+                                credentials.staffCode,
+                            )
+                        );
+                        if (!staffMfaVerified) throw new Error(INVALID);
+                        staffMfaVerifiedAt = Date.now();
+                    }
+                }
+
                 await clearAuthRateLimit('login-email', email);
 
                 // Return only non-sensitive fields (never the password hash).
@@ -74,6 +99,9 @@ export const authOptions: NextAuthOptions = {
                     image: user.image,
                     role: user.role,
                     authVersion: user.authVersion,
+                    staffMfaVerified,
+                    staffMfaEnrollmentRequired,
+                    staffMfaVerifiedAt,
                 };
             },
         }),
@@ -92,16 +120,37 @@ export const authOptions: NextAuthOptions = {
                 token.role = user.role;
                 token.authVersion = user.authVersion;
                 token.invalidated = false;
+                token.staffMfaVerified = user.staffMfaVerified;
+                token.staffMfaEnrollmentRequired = user.staffMfaEnrollmentRequired;
+                token.staffMfaVerifiedAt = user.staffMfaVerifiedAt;
             } else if (token.id) {
                 const currentUser = await prisma.user.findUnique({
                     where: { id: token.id },
-                    select: { role: true, authVersion: true, emailVerified: true },
+                    select: {
+                        role: true,
+                        authVersion: true,
+                        emailVerified: true,
+                        staffMfaEnrolledAt: true,
+                    },
                 });
+                const staffSessionExpired = token.role === 'ADMIN'
+                    && token.staffMfaVerified === true
+                    && (!token.staffMfaVerifiedAt
+                        || Date.now() - token.staffMfaVerifiedAt > STAFF_MFA_SESSION_MAX_AGE_MS);
                 token.invalidated = !currentUser
                     || !currentUser.emailVerified
-                    || currentUser.authVersion !== token.authVersion;
+                    || currentUser.authVersion !== token.authVersion
+                    || staffSessionExpired
+                    || (token.role === 'ADMIN'
+                        && token.staffMfaVerified === true
+                        && !currentUser.staffMfaEnrolledAt);
                 if (currentUser && !token.invalidated) {
                     token.role = currentUser.role;
+                    if (currentUser.role !== 'ADMIN') {
+                        token.staffMfaVerified = false;
+                        token.staffMfaEnrollmentRequired = false;
+                        delete token.staffMfaVerifiedAt;
+                    }
                 }
             }
             return token;
@@ -111,6 +160,8 @@ export const authOptions: NextAuthOptions = {
             if (session.user) {
                 session.user.id = token.id;
                 session.user.role = token.role;
+                session.user.staffMfaVerified = token.staffMfaVerified === true;
+                session.user.staffMfaEnrollmentRequired = token.staffMfaEnrollmentRequired === true;
             }
             return session;
         },

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,4 +1,5 @@
 import { parsePassengerDataEncryptionKeys } from '@/lib/passengerDataProtection';
+import { parseStaffMfaEncryptionKeys } from '@/lib/staffMfa';
 
 type RequiredEnvironmentVariable =
     | 'DATABASE_URL'
@@ -7,7 +8,8 @@ type RequiredEnvironmentVariable =
     | 'AUTH_EMAIL_FROM'
     | 'AUTH_EMAIL_PROVIDER'
     | 'AUTH_EMAIL_API_URL'
-    | 'PASSENGER_DATA_ENCRYPTION_KEYS';
+    | 'PASSENGER_DATA_ENCRYPTION_KEYS'
+    | 'STAFF_MFA_ENCRYPTION_KEYS';
 type Environment = Partial<Record<RequiredEnvironmentVariable, string | undefined>> & {
     NODE_ENV?: string;
     AUTH_TRUSTED_PROXY_HOPS?: string;
@@ -45,6 +47,8 @@ export function validateServerEnvironment(environment: Environment): ValidatedEn
     const AUTH_EMAIL_API_URL = requireValue(environment, 'AUTH_EMAIL_API_URL');
     const PASSENGER_DATA_ENCRYPTION_KEYS = requireValue(environment, 'PASSENGER_DATA_ENCRYPTION_KEYS');
     parsePassengerDataEncryptionKeys(PASSENGER_DATA_ENCRYPTION_KEYS);
+    const STAFF_MFA_ENCRYPTION_KEYS = requireValue(environment, 'STAFF_MFA_ENCRYPTION_KEYS');
+    parseStaffMfaEncryptionKeys(STAFF_MFA_ENCRYPTION_KEYS);
 
     const databaseUrl = parseUrl(DATABASE_URL, 'DATABASE_URL');
     if (!['postgresql:', 'postgres:'].includes(databaseUrl.protocol)) {
@@ -104,6 +108,7 @@ export function validateServerEnvironment(environment: Environment): ValidatedEn
         AUTH_EMAIL_PROVIDER,
         AUTH_EMAIL_API_URL,
         PASSENGER_DATA_ENCRYPTION_KEYS,
+        STAFF_MFA_ENCRYPTION_KEYS,
         ...(AUTH_EMAIL_API_TOKEN ? { AUTH_EMAIL_API_TOKEN } : {}),
         ...(AUTH_TRUSTED_PROXY_HOPS ? { AUTH_TRUSTED_PROXY_HOPS } : {})
     };

--- a/lib/staffAuthorization.ts
+++ b/lib/staffAuthorization.ts
@@ -1,0 +1,5 @@
+import { Session } from 'next-auth';
+
+export function hasVerifiedStaffAccess(session: Session | null): boolean {
+    return session?.user?.role === 'ADMIN' && session.user.staffMfaVerified === true;
+}

--- a/lib/staffMfa.ts
+++ b/lib/staffMfa.ts
@@ -1,0 +1,221 @@
+import {
+    createCipheriv,
+    createDecipheriv,
+    createHmac,
+    randomBytes,
+    timingSafeEqual,
+} from 'node:crypto';
+import { prisma } from '@/lib/prisma';
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const ALGORITHM = 'aes-256-gcm';
+const ENVELOPE_VERSION = 'v1';
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+const TOTP_STEP_MS = 30_000;
+const KEY_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9-]{0,31}$/;
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+export const STAFF_MFA_SESSION_MAX_AGE_MS = 8 * 60 * 60 * 1_000;
+
+export interface StaffMfaEncryptionKeys {
+    activeKeyId: string;
+    keys: ReadonlyMap<string, Buffer>;
+}
+
+function configurationError(message: string): Error {
+    return new Error(`STAFF_MFA_ENCRYPTION_KEYS ${message}`);
+}
+
+export function parseStaffMfaEncryptionKeys(value: string): StaffMfaEncryptionKeys {
+    const entries = value.trim().split(',').map(entry => entry.trim()).filter(Boolean);
+    if (entries.length === 0) throw configurationError('must contain at least one key');
+
+    const keys = new Map<string, Buffer>();
+    for (const entry of entries) {
+        const separator = entry.indexOf(':');
+        if (separator <= 0 || separator === entry.length - 1) {
+            throw configurationError('must use key-id:base64-key entries');
+        }
+        const keyId = entry.slice(0, separator);
+        const encodedKey = entry.slice(separator + 1);
+        if (!KEY_ID_PATTERN.test(keyId)) {
+            throw configurationError('contains an invalid key identifier');
+        }
+        if (keys.has(keyId)) {
+            throw configurationError(`contains duplicate key identifier ${keyId}`);
+        }
+        if (!BASE64_PATTERN.test(encodedKey)) {
+            throw configurationError(`contains invalid base64 for key ${keyId}`);
+        }
+        const key = Buffer.from(encodedKey, 'base64');
+        if (key.length !== 32) {
+            throw configurationError(`key ${keyId} must decode to exactly 32 bytes`);
+        }
+        keys.set(keyId, key);
+    }
+
+    return { activeKeyId: entries[0].slice(0, entries[0].indexOf(':')), keys };
+}
+
+function configuredKeys(): StaffMfaEncryptionKeys {
+    return parseStaffMfaEncryptionKeys(process.env.STAFF_MFA_ENCRYPTION_KEYS ?? '');
+}
+
+function encodeBase32(value: Buffer): string {
+    let bits = 0;
+    let accumulator = 0;
+    let output = '';
+    for (const byte of value) {
+        accumulator = (accumulator << 8) | byte;
+        bits += 8;
+        while (bits >= 5) {
+            output += BASE32_ALPHABET[(accumulator >>> (bits - 5)) & 31];
+            bits -= 5;
+        }
+    }
+    if (bits > 0) output += BASE32_ALPHABET[(accumulator << (5 - bits)) & 31];
+    return output;
+}
+
+function decodeBase32(value: string): Buffer {
+    const normalized = value.trim().replace(/\s+/g, '').toUpperCase().replace(/=+$/g, '');
+    if (!normalized || !/^[A-Z2-7]+$/.test(normalized)) throw new Error('Invalid TOTP secret');
+
+    let bits = 0;
+    let accumulator = 0;
+    const output: number[] = [];
+    for (const character of normalized) {
+        accumulator = (accumulator << 5) | BASE32_ALPHABET.indexOf(character);
+        bits += 5;
+        if (bits >= 8) {
+            output.push((accumulator >>> (bits - 8)) & 255);
+            bits -= 8;
+        }
+    }
+    return Buffer.from(output);
+}
+
+export function generateStaffMfaSecret(): string {
+    return encodeBase32(randomBytes(20));
+}
+
+function codeForStep(secret: string, step: number, digits: number): string {
+    const counter = Buffer.alloc(8);
+    counter.writeBigUInt64BE(BigInt(step));
+    const digest = createHmac('sha1', decodeBase32(secret)).update(counter).digest();
+    const offset = digest[digest.length - 1] & 0x0f;
+    const binary = (
+        ((digest[offset] & 0x7f) << 24)
+        | ((digest[offset + 1] & 0xff) << 16)
+        | ((digest[offset + 2] & 0xff) << 8)
+        | (digest[offset + 3] & 0xff)
+    ) >>> 0;
+    return String(binary % (10 ** digits)).padStart(digits, '0');
+}
+
+export function createStaffTotpCode(secret: string, now = new Date(), digits = 6): string {
+    if (!Number.isInteger(digits) || digits < 6 || digits > 8) {
+        throw new Error('TOTP digits must be between 6 and 8.');
+    }
+    return codeForStep(secret, Math.floor(now.getTime() / TOTP_STEP_MS), digits);
+}
+
+export function verifyStaffTotpCode(secret: string, code: string, now = new Date()): number | null {
+    const normalizedCode = code.trim();
+    if (!/^\d{6}$/.test(normalizedCode)) return null;
+
+    const currentStep = Math.floor(now.getTime() / TOTP_STEP_MS);
+    for (const step of [currentStep, currentStep - 1, currentStep + 1]) {
+        const expected = Buffer.from(codeForStep(secret, step, 6));
+        const supplied = Buffer.from(normalizedCode);
+        if (expected.length === supplied.length && timingSafeEqual(expected, supplied)) return step;
+    }
+    return null;
+}
+
+function authenticatedContext(userId: string): Buffer {
+    return Buffer.from(`travel-app:staff-mfa:${userId}`, 'utf8');
+}
+
+export function encryptStaffMfaSecret(
+    secret: string,
+    userId: string,
+    keyRing = configuredKeys(),
+): string {
+    const key = keyRing.keys.get(keyRing.activeKeyId);
+    if (!key) throw configurationError('does not contain its active key');
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_BYTES });
+    cipher.setAAD(authenticatedContext(userId));
+    const ciphertext = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
+    return [
+        ENVELOPE_VERSION,
+        keyRing.activeKeyId,
+        iv.toString('base64url'),
+        ciphertext.toString('base64url'),
+        cipher.getAuthTag().toString('base64url'),
+    ].join(':');
+}
+
+export function decryptStaffMfaSecret(
+    envelope: string,
+    userId: string,
+    keyRing = configuredKeys(),
+): string {
+    try {
+        const [version, keyId, encodedIv, encodedCiphertext, encodedTag, ...extra] = envelope.split(':');
+        if (version !== ENVELOPE_VERSION || extra.length > 0) throw new Error('Invalid envelope');
+        const key = keyRing.keys.get(keyId);
+        if (!key) throw new Error('Unknown key');
+        const iv = Buffer.from(encodedIv, 'base64url');
+        const ciphertext = Buffer.from(encodedCiphertext, 'base64url');
+        const tag = Buffer.from(encodedTag, 'base64url');
+        if (iv.length !== IV_BYTES || tag.length !== AUTH_TAG_BYTES) throw new Error('Invalid envelope');
+        const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_BYTES });
+        decipher.setAAD(authenticatedContext(userId));
+        decipher.setAuthTag(tag);
+        return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+    } catch {
+        throw new Error('Unable to decrypt staff MFA secret');
+    }
+}
+
+export function createStaffMfaOtpAuthUri(secret: string, email: string): string {
+    const issuer = 'Mona Airways';
+    const label = `${issuer}:${email}`;
+    const query = new URLSearchParams({ secret, issuer, algorithm: 'SHA1', digits: '6', period: '30' });
+    return `otpauth://totp/${encodeURIComponent(label)}?${query.toString()}`;
+}
+
+export async function verifyAndConsumeStaffTotp(
+    userId: string,
+    encryptedSecret: string,
+    code: string,
+): Promise<boolean> {
+    try {
+        const keyRing = configuredKeys();
+        const secret = decryptStaffMfaSecret(encryptedSecret, userId, keyRing);
+        const matchedStep = verifyStaffTotpCode(secret, code);
+        if (matchedStep === null) return false;
+
+        const result = await prisma.user.updateMany({
+            where: {
+                id: userId,
+                staffMfaSecretEncrypted: encryptedSecret,
+                staffMfaEnrolledAt: { not: null },
+                OR: [
+                    { staffMfaLastUsedStep: null },
+                    { staffMfaLastUsedStep: { lt: matchedStep } },
+                ],
+            },
+            data: {
+                staffMfaLastUsedStep: matchedStep,
+                staffMfaSecretEncrypted: encryptStaffMfaSecret(secret, userId, keyRing),
+            },
+        });
+        return result.count === 1;
+    } catch {
+        return false;
+    }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/reporters */
   reporter: process.env.CI ? 'dot' : 'html',
+  globalSetup: './e2e/global-setup.ts',
+  globalTeardown: './e2e/global-teardown.ts',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/prisma/migrations/20260714020000_add_staff_mfa/migration.sql
+++ b/prisma/migrations/20260714020000_add_staff_mfa/migration.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "User"
+    ADD COLUMN "staffMfaSecretEncrypted" TEXT,
+    ADD COLUMN "staffMfaEnrolledAt" TIMESTAMP(3),
+    ADD COLUMN "staffMfaLastUsedStep" INTEGER;
+
+ALTER TABLE "User"
+ADD CONSTRAINT "User_staff_mfa_state_check"
+CHECK (
+    (
+        "staffMfaEnrolledAt" IS NULL
+        AND "staffMfaLastUsedStep" IS NULL
+    )
+    OR (
+        "staffMfaSecretEncrypted" IS NOT NULL
+        AND "staffMfaEnrolledAt" IS NOT NULL
+    )
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,9 @@ model User {
   password      String?
   role          Role           @default(USER)
   authVersion   Int            @default(0)
+  staffMfaSecretEncrypted String? @db.Text
+  staffMfaEnrolledAt      DateTime?
+  staffMfaLastUsedStep    Int?
   accounts      Account[]
   sessions      Session[]
   bookings      Booking[]

--- a/proxy.ts
+++ b/proxy.ts
@@ -5,6 +5,9 @@ export default withAuth({
         authorized: ({ req, token }) => {
             // Protect admin routes to only users with 'ADMIN' role
             if (req.nextUrl.pathname.startsWith('/admin')) {
+                return token?.role === 'ADMIN' && token.staffMfaVerified === true;
+            }
+            if (req.nextUrl.pathname.startsWith('/staff/mfa')) {
                 return token?.role === 'ADMIN';
             }
             // Require authentication for other protected routes
@@ -14,5 +17,5 @@ export default withAuth({
 });
 
 export const config = {
-    matcher: ['/profile/:path*', '/book/:path*', '/admin/:path*'],
+    matcher: ['/profile/:path*', '/book/:path*', '/admin/:path*', '/staff/mfa/:path*'],
 };

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -16,6 +16,7 @@ require_value DATABASE_URL
 require_value NEXTAUTH_URL
 require_value NEXTAUTH_SECRET
 require_value PASSENGER_DATA_ENCRYPTION_KEYS
+require_value STAFF_MFA_ENCRYPTION_KEYS
 require_value AUTH_TRUSTED_PROXY_HOPS
 require_value AUTH_EMAIL_FROM
 require_value AUTH_EMAIL_PROVIDER

--- a/scripts/verify-container-secrets.sh
+++ b/scripts/verify-container-secrets.sh
@@ -32,13 +32,13 @@ image_labels="$($container_runtime image inspect \
   --format '{{json .Config.Labels}}' "$image")"
 
 if printf '%s\n' "$image_environment" | \
-  grep -Eq '^(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET|AUTH_EMAIL_API_TOKEN|PASSENGER_DATA_ENCRYPTION_KEYS)='; then
+  grep -Eq '^(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET|AUTH_EMAIL_API_TOKEN|PASSENGER_DATA_ENCRYPTION_KEYS|STAFF_MFA_ENCRYPTION_KEYS)='; then
   echo "Sensitive runtime configuration key found in image environment." >&2
   exit 1
 fi
 
 if printf '%s\n' "$image_labels" | \
-  grep -Eq '"(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET|AUTH_EMAIL_API_TOKEN|PASSENGER_DATA_ENCRYPTION_KEYS)"[[:space:]]*:'; then
+  grep -Eq '"(DATABASE_URL|NEXTAUTH_URL|NEXTAUTH_SECRET|AUTH_EMAIL_API_TOKEN|PASSENGER_DATA_ENCRYPTION_KEYS|STAFF_MFA_ENCRYPTION_KEYS)"[[:space:]]*:'; then
   echo "Sensitive runtime configuration key found in image labels." >&2
   exit 1
 fi

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -8,6 +8,8 @@ declare module 'next-auth' {
         user: {
             id: string;
             role: Role;
+            staffMfaVerified: boolean;
+            staffMfaEnrollmentRequired: boolean;
         } & NonNullable<DefaultSession['user']>;
     }
 
@@ -15,6 +17,9 @@ declare module 'next-auth' {
     interface User {
         role: Role;
         authVersion: number;
+        staffMfaVerified: boolean;
+        staffMfaEnrollmentRequired: boolean;
+        staffMfaVerifiedAt?: number;
     }
 }
 
@@ -24,5 +29,8 @@ declare module 'next-auth/jwt' {
         role: Role;
         authVersion: number;
         invalidated?: boolean;
+        staffMfaVerified: boolean;
+        staffMfaEnrollmentRequired: boolean;
+        staffMfaVerifiedAt?: number;
     }
 }


### PR DESCRIPTION
## Summary

Implements roadmap item P0.5 by requiring staff MFA before ADMIN users can access admin routes or privileged server actions.

- adds encrypted TOTP enrollment for staff accounts, replay-resistant code consumption, and an 8-hour verified staff proof
- gates admin layouts, middleware, navigation, and mutations on verified staff access
- adds staff MFA secret validation, docs, env/container checks, and Prisma migration coverage
- narrows public/admin Prisma projections so password hashes and staff MFA material are not loaded or serialized unnecessarily

## Validation

- `npx prisma generate`
- `npx prisma migrate deploy`
- `docker compose up -d --build`
- focused Jest: TravelGuideClient/titlebar, staff MFA/auth suites
- `npx jest --runInBand` — 50 suites / 366 tests passed
- `npx tsc --noEmit`
- `npm run lint` — passed with 8 pre-existing warnings
- `npm run build`
- focused Playwright travelguide/admin checks
- `npx playwright test` — 14/14 passed
- `git diff --check`
