### PR TITLE
feat(search): enforce booking window

### DIFF
--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -507,4 +507,4 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-14 | P0.5 | Complete | #43 | Required TOTP for staff accounts, limited first-time enrollment sessions, encrypted authenticator secrets, replay-resistant codes, and an eight-hour staff authentication window. |
 | 2026-07-14 | P1.1 | In progress | #45 | Defaulted each route to its next future operating date and covered the seeded default search journey. Date constraints, nearby dates, URL state, and service states remain. |
 | 2026-07-17 | P1.1 | In progress | #46 | Rejected past departures and invalid return ordering in the UI and server, and excluded already-departed inventory from same-day results. Booking windows and later search slices remain. |
-| 2026-07-18 | P1.1 | In progress | Pending | Enforced an inclusive same-day through 365-day booking window for departures and returns in the UI and server. Nearby dates, URL state, and service states remain. |
+| 2026-07-18 | P1.1 | In progress | #47 | Enforced an inclusive same-day through 365-day booking window for departures and returns in the UI and server. Nearby dates, URL state, and service states remain. |

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -122,7 +122,8 @@ journey succeeds.
 
 - [x] Default to the next operating date for the selected route.
 - [x] Prevent past departures and returns before departure.
-- [ ] Add minimum/maximum booking-window rules.
+- [x] Add minimum/maximum booking-window rules (same-day through 365 days,
+  inclusive; interim UTC day boundary).
 - [ ] Suggest nearby operating dates when no exact match exists.
 - [ ] Preserve search criteria in URL parameters.
 - [ ] Add loading, empty, failure, retry, and degraded-service states.
@@ -506,3 +507,4 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-14 | P0.5 | Complete | #43 | Required TOTP for staff accounts, limited first-time enrollment sessions, encrypted authenticator secrets, replay-resistant codes, and an eight-hour staff authentication window. |
 | 2026-07-14 | P1.1 | In progress | #45 | Defaulted each route to its next future operating date and covered the seeded default search journey. Date constraints, nearby dates, URL state, and service states remain. |
 | 2026-07-17 | P1.1 | In progress | #46 | Rejected past departures and invalid return ordering in the UI and server, and excluded already-departed inventory from same-day results. Booking windows and later search slices remain. |
+| 2026-07-18 | P1.1 | In progress | Pending | Enforced an inclusive same-day through 365-day booking window for departures and returns in the UI and server. Nearby dates, URL state, and service states remain. |

--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -296,6 +296,41 @@ describe('searchFlightsAction', () => {
         expect(mockGenerateFlightsForDate).not.toHaveBeenCalled();
         expect(mockedFlightFindMany).not.toHaveBeenCalled();
     });
+
+    it('rejects travel beyond the booking window before database access', async () => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-07-14T12:00:00.000Z'));
+
+        await expect(searchFlightsAction(
+            'Seattle, USA',
+            'Detroit, USA',
+            '2027-07-15',
+        )).resolves.toMatchObject({
+            ok: false,
+            error: {
+                code: 'VALIDATION_ERROR',
+                fields: {
+                    departureDate: ['Departure date cannot be more than 365 days in advance.'],
+                },
+            },
+        });
+        await expect(searchFlightsAction(
+            'Seattle, USA',
+            'Detroit, USA',
+            '2027-07-14',
+            '2027-07-15',
+        )).resolves.toMatchObject({
+            ok: false,
+            error: {
+                code: 'VALIDATION_ERROR',
+                fields: {
+                    returnDate: ['Return date cannot be more than 365 days in advance.'],
+                },
+            },
+        });
+
+        expect(mockGenerateFlightsForDate).not.toHaveBeenCalled();
+        expect(mockedFlightFindMany).not.toHaveBeenCalled();
+    });
 });
 
 describe('getFlightRoutesAction', () => {

--- a/__tests__/components/flightBookingForm.test.tsx
+++ b/__tests__/components/flightBookingForm.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import FlightBookingForm from '@/components/ui/flightBookingForm';
 import { bookFlightAction, searchFlightsAction } from '@/app/actions';
@@ -81,11 +81,19 @@ const mockEnhancedFlights = [
 ];
 
 const renderForm = () => render(
-    <FlightBookingForm routes={routes} minimumDepartureDate="2026-07-14" />
+    <FlightBookingForm
+        routes={routes}
+        minimumDepartureDate="2026-07-14"
+        maximumDepartureDate="2027-07-14"
+    />
 );
 
 describe('FlightBookingForm', () => {
-    beforeEach(() => jest.clearAllMocks());
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-07-14T12:00:00.000Z'));
+        jest.clearAllMocks();
+    });
+    afterEach(() => jest.useRealTimers());
 
     it('renders origins and the destinations reachable from the default origin', () => {
         renderForm();
@@ -112,8 +120,10 @@ describe('FlightBookingForm', () => {
 
         expect(screen.getByLabelText('Depart')).toHaveValue('2026-07-15');
         expect(screen.getByLabelText('Depart')).toHaveAttribute('min', '2026-07-14');
+        expect(screen.getByLabelText('Depart')).toHaveAttribute('max', '2027-07-14');
         expect(screen.getByLabelText('Return')).toHaveValue('2026-07-22');
         expect(screen.getByLabelText('Return')).toHaveAttribute('min', '2026-07-15');
+        expect(screen.getByLabelText('Return')).toHaveAttribute('max', '2027-07-14');
 
         fireEvent.change(screen.getByLabelText('To'), { target: { value: 'Tokyo, Japan' } });
 
@@ -121,6 +131,30 @@ describe('FlightBookingForm', () => {
             expect(screen.getByLabelText('Depart')).toHaveValue('2026-07-16');
             expect(screen.getByLabelText('Return')).toHaveValue('2026-07-23');
         });
+    });
+
+    it('refreshes the booking window when the UTC day changes', () => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-07-14T23:59:59.000Z'));
+        renderForm();
+
+        expect(screen.getByLabelText('Depart')).toHaveAttribute('min', '2026-07-14');
+        expect(screen.getByLabelText('Depart')).toHaveAttribute('max', '2027-07-14');
+
+        act(() => jest.advanceTimersByTime(1_001));
+
+        expect(screen.getByLabelText('Depart')).toHaveAttribute('min', '2026-07-15');
+        expect(screen.getByLabelText('Depart')).toHaveAttribute('max', '2027-07-15');
+        expect(screen.getByLabelText('Return')).toHaveAttribute('max', '2027-07-15');
+    });
+
+    it('reconciles a stale server booking window during hydration', () => {
+        jest.setSystemTime(new Date('2026-07-15T00:00:01.000Z'));
+
+        renderForm();
+
+        expect(screen.getByLabelText('Depart')).toHaveAttribute('min', '2026-07-15');
+        expect(screen.getByLabelText('Depart')).toHaveAttribute('max', '2027-07-15');
+        expect(screen.getByLabelText('Return')).toHaveAttribute('max', '2027-07-15');
     });
 
     it('searches using the selected origin and destination', async () => {
@@ -196,6 +230,28 @@ describe('FlightBookingForm', () => {
         await waitFor(() => {
             expect(screen.queryByRole('alert')).not.toBeInTheDocument();
         });
+    });
+
+    it('rejects departures and returns beyond the booking window before searching', async () => {
+        renderForm();
+        const form = screen.getByRole('button', { name: 'Find your trip' }).closest('form');
+        expect(form).not.toBeNull();
+
+        fireEvent.change(screen.getByLabelText('Depart'), { target: { value: '2027-07-15' } });
+        fireEvent.submit(form!);
+        expect(await screen.findByRole('alert')).toHaveTextContent(
+            'Departure date cannot be more than 365 days in advance.'
+        );
+        expect(mockSearch).not.toHaveBeenCalled();
+
+        fireEvent.change(screen.getByLabelText('Depart'), { target: { value: '2027-07-14' } });
+        expect(screen.getByLabelText('Return')).toHaveValue('2027-07-14');
+        fireEvent.change(screen.getByLabelText('Return'), { target: { value: '2027-07-15' } });
+        fireEvent.submit(form!);
+        expect(await screen.findByRole('alert')).toHaveTextContent(
+            'Return date cannot be more than 365 days in advance.'
+        );
+        expect(mockSearch).not.toHaveBeenCalled();
     });
 
     it('shows a no-results message when no flights match the route', async () => {

--- a/__tests__/lib/dates.test.ts
+++ b/__tests__/lib/dates.test.ts
@@ -1,0 +1,19 @@
+import {
+    MAX_BOOKING_LEAD_DAYS,
+    MIN_BOOKING_LEAD_DAYS,
+    earliestBookableDateIso,
+    latestBookableDateIso,
+} from '@/lib/dates';
+
+describe('booking window dates', () => {
+    afterEach(() => jest.useRealTimers());
+
+    it('defines an inclusive same-day through 365-day booking window', () => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-07-14T23:59:59.000Z'));
+
+        expect(MIN_BOOKING_LEAD_DAYS).toBe(0);
+        expect(MAX_BOOKING_LEAD_DAYS).toBe(365);
+        expect(earliestBookableDateIso()).toBe('2026-07-14');
+        expect(latestBookableDateIso()).toBe('2027-07-14');
+    });
+});

--- a/__tests__/lib/validation.test.ts
+++ b/__tests__/lib/validation.test.ts
@@ -262,6 +262,42 @@ describe('shared server validation schemas', () => {
         ]));
     });
 
+    it('accepts the booking-window boundary and rejects later travel', () => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-07-14T12:00:00.000Z'));
+
+        expect(searchFlightsSchema.safeParse({
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            departureDate: '2027-07-14',
+            returnDate: '2027-07-14',
+        }).success).toBe(true);
+
+        const lateDeparture = searchFlightsSchema.safeParse({
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            departureDate: '2027-07-15',
+        });
+        const lateReturn = searchFlightsSchema.safeParse({
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            departureDate: '2027-07-14',
+            returnDate: '2027-07-15',
+        });
+
+        expect(lateDeparture.error?.issues).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                path: ['departureDate'],
+                message: 'Departure date cannot be more than 365 days in advance.',
+            }),
+        ]));
+        expect(lateReturn.error?.issues).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                path: ['returnDate'],
+                message: 'Return date cannot be more than 365 days in advance.',
+            }),
+        ]));
+    });
+
     it('covers exact city-guide and schedule boundaries', () => {
         const imagePrefix = 'data:image/png;base64,';
         const boundaryGuide = {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import FlightBookingForm from "../components/ui/flightBookingForm";
 import { getFlightRoutesAction } from "./actions";
-import { todayIsoDate } from "@/lib/dates";
+import { bookingWindowIsoDates } from "@/lib/dates";
 
 // Reads live flight inventory from the DB, so render per-request rather than
 // statically prerendering at build time (which would need a database).
@@ -9,10 +9,12 @@ export const dynamic = 'force-dynamic';
 
 export default async function Home() {
   const routes = await getFlightRoutesAction();
+  const { earliestDate, latestDate } = bookingWindowIsoDates();
   return (
     <FlightBookingForm
       routes={routes}
-      minimumDepartureDate={todayIsoDate()}
+      minimumDepartureDate={earliestDate}
+      maximumDepartureDate={latestDate}
     />
   );
 }

--- a/components/ui/flightBookingForm.tsx
+++ b/components/ui/flightBookingForm.tsx
@@ -1,17 +1,25 @@
 "use client"
 
 import * as React from 'react'
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import Link from 'next/link'
 import { searchFlightsAction } from '@/app/actions'
 import { Flight } from '@prisma/client'
 import { isActionValidationFailure } from '@/lib/actionResult'
 import type { FlightRoute } from '@/lib/flightSearch'
-import { todayIsoDate } from '@/lib/dates'
+import {
+    DEPARTURE_AFTER_BOOKING_WINDOW_MESSAGE,
+    RETURN_AFTER_BOOKING_WINDOW_MESSAGE,
+    addDaysToIsoDate,
+    bookingWindowIsoDates,
+    earliestBookableDateIso,
+    latestBookableDateIso,
+} from '@/lib/dates'
 
 interface FlightBookingFormProps {
     routes?: FlightRoute[];
     minimumDepartureDate?: string;
+    maximumDepartureDate?: string;
 }
 
 type BookingState = {
@@ -24,18 +32,29 @@ type BookingState = {
 const DEPARTURE_REQUIRED_WITH_RETURN_MESSAGE =
     'Departure date is required when a return date is provided.';
 
-function addDaysToIsoDate(dateString: string, days: number): string {
-    if (!dateString) return '';
+function clampToMaximumDate(dateString: string, maximumDate: string): string {
+    return dateString && dateString > maximumDate ? maximumDate : dateString;
+}
 
-    const date = new Date(`${dateString}T00:00:00.000Z`);
-    date.setUTCDate(date.getUTCDate() + days);
-    return date.toISOString().slice(0, 10);
+function millisecondsUntilNextUtcDay(referenceDate = new Date()): number {
+    const nextUtcDay = Date.UTC(
+        referenceDate.getUTCFullYear(),
+        referenceDate.getUTCMonth(),
+        referenceDate.getUTCDate() + 1,
+    );
+    return nextUtcDay - referenceDate.getTime();
 }
 
 const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     routes = [],
-    minimumDepartureDate = todayIsoDate(),
+    minimumDepartureDate = earliestBookableDateIso(),
+    maximumDepartureDate = latestBookableDateIso(),
 }) => {
+    const [bookingWindow, setBookingWindow] = useState({
+        earliestDate: minimumDepartureDate,
+        latestDate: maximumDepartureDate,
+    });
+    const latestBookingDateRef = useRef(maximumDepartureDate);
     // Origins are the distinct departure cities; destinations depend on the
     // selected origin so only reachable routes can be chosen.
     const origins = useMemo(() => Array.from(new Set(routes.map((r) => r.from))), [routes]);
@@ -48,7 +67,12 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     const initialDepartureDate = routes[0]?.nextOperatingDate ?? '';
     const [departureDate, setDepartureDate] = useState<string>(initialDepartureDate);
     const [returnDate, setReturnDate] = useState<string>(
-        addDaysToIsoDate(initialDepartureDate, 7)
+        initialDepartureDate
+            ? clampToMaximumDate(
+                addDaysToIsoDate(initialDepartureDate, 7),
+                bookingWindow.latestDate
+            )
+            : ''
     );
     const [flightClass, setFlightClass] = useState('economy');
     const [isOneWay, setIsOneWay] = useState(false);
@@ -81,10 +105,17 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
         setSearchResults(null);
         setBookingState({ status: 'idle' });
 
-        if (departureDate && departureDate < minimumDepartureDate) {
+        if (departureDate && departureDate < bookingWindow.earliestDate) {
             setBookingState({
                 status: 'error',
                 message: 'Departure date cannot be in the past.',
+            });
+            return;
+        }
+        if (departureDate && departureDate > bookingWindow.latestDate) {
+            setBookingState({
+                status: 'error',
+                message: DEPARTURE_AFTER_BOOKING_WINDOW_MESSAGE,
             });
             return;
         }
@@ -100,6 +131,14 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
             setBookingState({
                 status: 'error',
                 message: 'Return date cannot be before departure date.',
+                clearOnOneWay: true,
+            });
+            return;
+        }
+        if (!isOneWay && returnDate && returnDate > bookingWindow.latestDate) {
+            setBookingState({
+                status: 'error',
+                message: RETURN_AFTER_BOOKING_WINDOW_MESSAGE,
                 clearOnOneWay: true,
             });
             return;
@@ -150,7 +189,33 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     }, [fromLocation, routes, toLocation]);
 
     useEffect(() => {
-        setReturnDate(isOneWay ? '' : addDaysToIsoDate(departureDate, 7));
+        const currentBookingWindow = bookingWindowIsoDates();
+        if (
+            currentBookingWindow.earliestDate !== bookingWindow.earliestDate
+            || currentBookingWindow.latestDate !== bookingWindow.latestDate
+        ) {
+            latestBookingDateRef.current = currentBookingWindow.latestDate;
+            setBookingWindow(currentBookingWindow);
+        }
+
+        const rolloverTimer = window.setTimeout(() => {
+            const nextBookingWindow = bookingWindowIsoDates();
+            latestBookingDateRef.current = nextBookingWindow.latestDate;
+            setBookingWindow(nextBookingWindow);
+        }, millisecondsUntilNextUtcDay() + 1);
+
+        return () => window.clearTimeout(rolloverTimer);
+    }, [bookingWindow.earliestDate, bookingWindow.latestDate]);
+
+    useEffect(() => {
+        const proposedReturnDate = departureDate
+            ? addDaysToIsoDate(departureDate, 7)
+            : '';
+        setReturnDate(
+            isOneWay
+                ? ''
+                : clampToMaximumDate(proposedReturnDate, latestBookingDateRef.current)
+        );
     }, [departureDate, isOneWay]);
 
     // Helper to parse price string to number safely (handles $ and commas)
@@ -296,7 +361,8 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                             type="date"
                             id="depart"
                             name="depart"
-                            min={minimumDepartureDate}
+                            min={bookingWindow.earliestDate}
+                            max={bookingWindow.latestDate}
                             value={departureDate}
                             onChange={e => setDepartureDate(e.target.value)}
                         />
@@ -310,7 +376,8 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                             id="returnDate"
                             name="returnDate"
                             className="w-full p-2 border border-gray-300 rounded text-lg"
-                            min={departureDate || minimumDepartureDate}
+                            min={departureDate || bookingWindow.earliestDate}
+                            max={bookingWindow.latestDate}
                             value={returnDate}
                             onChange={(e) => setReturnDate(e.target.value)}
                             disabled={isOneWay}

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -20,13 +20,29 @@ test.describe('Flight search', () => {
     const returnDate = page.getByLabel('Return');
     const form = page.locator('form');
     const today = new Date().toISOString().slice(0, 10);
+    const latest = new Date(`${today}T00:00:00.000Z`);
+    latest.setUTCDate(latest.getUTCDate() + 365);
+    const latestString = latest.toISOString().slice(0, 10);
+    const beyondLatest = new Date(latest);
+    beyondLatest.setUTCDate(beyondLatest.getUTCDate() + 1);
+    const beyondLatestString = beyondLatest.toISOString().slice(0, 10);
     const yesterday = new Date(`${today}T00:00:00.000Z`);
     yesterday.setUTCDate(yesterday.getUTCDate() - 1);
     const yesterdayString = yesterday.toISOString().slice(0, 10);
     const validDeparture = await departure.inputValue();
 
     await expect(departure).toHaveAttribute('min', today);
+    await expect(departure).toHaveAttribute('max', latestString);
     await expect(returnDate).toHaveAttribute('min', validDeparture);
+    await expect(returnDate).toHaveAttribute('max', latestString);
+
+    await departure.fill(beyondLatestString);
+    await form.evaluate((element) => {
+      element.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+    await expect(page.getByRole('alert').filter({
+      hasText: 'Departure date cannot be more than 365 days in advance.',
+    })).toBeVisible();
 
     await departure.fill(yesterdayString);
     await form.evaluate((element) => {

--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -1,14 +1,47 @@
+export const MIN_BOOKING_LEAD_DAYS = 0;
+export const MAX_BOOKING_LEAD_DAYS = 365;
+
+export const DEPARTURE_AFTER_BOOKING_WINDOW_MESSAGE =
+    `Departure date cannot be more than ${MAX_BOOKING_LEAD_DAYS} days in advance.`;
+export const RETURN_AFTER_BOOKING_WINDOW_MESSAGE =
+    `Return date cannot be more than ${MAX_BOOKING_LEAD_DAYS} days in advance.`;
+
+export function addDaysToIsoDate(dateString: string, days: number): string {
+    const date = new Date(`${dateString}T00:00:00.000Z`);
+    date.setUTCDate(date.getUTCDate() + days);
+    return date.toISOString().slice(0, 10);
+}
+
+export function bookingWindowIsoDates(referenceDate = new Date()): {
+    earliestDate: string;
+    latestDate: string;
+} {
+    const today = todayIsoDate(referenceDate);
+    return {
+        earliestDate: addDaysToIsoDate(today, MIN_BOOKING_LEAD_DAYS),
+        latestDate: addDaysToIsoDate(today, MAX_BOOKING_LEAD_DAYS),
+    };
+}
+
 /**
  * The current date as an ISO `YYYY-MM-DD` string.
  *
  * Anchored to UTC, matching how flight dates are modeled throughout the app
  * (see `FlightScheduleService`, which stores departure times as UTC wall-clock
  * values). This is the single source of truth for "today" used by the search
- * date constraints on both the client and the server schema, so the past-date
- * rule stays consistent across the two. Displaying flight times in an airport's
- * local timezone is tracked separately and would require per-airport timezone
- * data that the schema does not yet carry.
+ * date constraints, including the booking-window helpers, so the client and
+ * server stay consistent. Displaying flight times in an airport's local
+ * timezone is tracked separately and would require per-airport timezone data
+ * that the schema does not yet carry.
  */
-export function todayIsoDate(): string {
-    return new Date().toISOString().slice(0, 10);
+export function todayIsoDate(referenceDate = new Date()): string {
+    return referenceDate.toISOString().slice(0, 10);
+}
+
+export function earliestBookableDateIso(): string {
+    return bookingWindowIsoDates().earliestDate;
+}
+
+export function latestBookableDateIso(): string {
+    return bookingWindowIsoDates().latestDate;
 }

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -2,7 +2,11 @@ import { z, ZodError, ZodType } from 'zod';
 import { validateSeatingLayout } from '@/lib/seatLayout';
 import { ActionValidationFailure } from '@/lib/actionResult';
 import { isValidAuthToken } from '@/lib/authTokenFormat';
-import { todayIsoDate } from '@/lib/dates';
+import {
+    DEPARTURE_AFTER_BOOKING_WINDOW_MESSAGE,
+    RETURN_AFTER_BOOKING_WINDOW_MESSAGE,
+    bookingWindowIsoDates,
+} from '@/lib/dates';
 
 export const MAX_MUTATION_BYTES = 1_000_000;
 export const MAX_REGISTRATION_BYTES = 16_384;
@@ -105,13 +109,23 @@ export const searchFlightsSchema = z.object({
     departureDate: isoDateSchema.optional(),
     returnDate: isoDateSchema.optional(),
 }).strict().superRefine(({ departureDate, returnDate }, context) => {
-    const today = todayIsoDate();
+    const {
+        earliestDate: earliestBookableDate,
+        latestDate: latestBookableDate,
+    } = bookingWindowIsoDates();
 
-    if (departureDate && departureDate < today) {
+    if (departureDate && departureDate < earliestBookableDate) {
         context.addIssue({
             code: 'custom',
             path: ['departureDate'],
             message: 'Departure date cannot be in the past.',
+        });
+    }
+    if (departureDate && departureDate > latestBookableDate) {
+        context.addIssue({
+            code: 'custom',
+            path: ['departureDate'],
+            message: DEPARTURE_AFTER_BOOKING_WINDOW_MESSAGE,
         });
     }
 
@@ -126,6 +140,13 @@ export const searchFlightsSchema = z.object({
             code: 'custom',
             path: ['returnDate'],
             message: 'Return date cannot be before departure date.',
+        });
+    }
+    if (returnDate && returnDate > latestBookableDate) {
+        context.addIssue({
+            code: 'custom',
+            path: ['returnDate'],
+            message: RETURN_AFTER_BOOKING_WINDOW_MESSAGE,
         });
     }
 });


### PR DESCRIPTION
## Summary

- define an inclusive UTC booking window from today through 365 days ahead
- enforce the same departure and return limits in the form and server schema
- refresh client limits across UTC midnight and reconcile stale SSR limits at hydration
- clamp the default return date at the booking-window boundary
- record the completed P1.1 booking-window slice in the roadmap

## Why

Search previously rejected past travel but accepted arbitrarily distant dates. This slice gives the date controls and server action one authoritative, tested booking-window policy while retaining same-day searches.

## Verification

- TypeScript passed
- ESLint passed with 8 known pre-existing warnings
- Jest: 52 suites, 382 tests passed
- production build passed
- Docker Compose app/proxy build and health checks passed
- Playwright search E2E: 2 passed
- responsive UI review passed at phone, tablet, and desktop viewports
- final code review approved with no findings

Roadmap: P1.1
