### PR TITLE
feat(search): suggest nearby flight dates

### DIFF
--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -509,4 +509,4 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-14 | P1.1 | In progress | #45 | Defaulted each route to its next future operating date and covered the seeded default search journey. Date constraints, nearby dates, URL state, and service states remain. |
 | 2026-07-17 | P1.1 | In progress | #46 | Rejected past departures and invalid return ordering in the UI and server, and excluded already-departed inventory from same-day results. Booking windows and later search slices remain. |
 | 2026-07-18 | P1.1 | In progress | #47 | Enforced an inclusive same-day through 365-day booking window for departures and returns in the UI and server. Nearby dates, URL state, and service states remain. |
-| 2026-07-18 | P1.1 | In progress | Pending | Suggested the nearest earlier and later operating dates for empty exact-date searches and made each suggestion searchable. URL state and service states remain. |
+| 2026-07-18 | P1.1 | In progress | #48 | Suggested the nearest earlier and later operating dates for empty exact-date searches and made each suggestion searchable. URL state and service states remain. |

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -124,7 +124,8 @@ journey succeeds.
 - [x] Prevent past departures and returns before departure.
 - [x] Add minimum/maximum booking-window rules (same-day through 365 days,
   inclusive; interim UTC day boundary).
-- [ ] Suggest nearby operating dates when no exact match exists.
+- [x] Suggest the nearest earlier and later operating dates when no exact match
+  exists.
 - [ ] Preserve search criteria in URL parameters.
 - [ ] Add loading, empty, failure, retry, and degraded-service states.
 - [ ] Base the earliest selectable date and the past-departure rule on the origin
@@ -508,3 +509,4 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-14 | P1.1 | In progress | #45 | Defaulted each route to its next future operating date and covered the seeded default search journey. Date constraints, nearby dates, URL state, and service states remain. |
 | 2026-07-17 | P1.1 | In progress | #46 | Rejected past departures and invalid return ordering in the UI and server, and excluded already-departed inventory from same-day results. Booking windows and later search slices remain. |
 | 2026-07-18 | P1.1 | In progress | #47 | Enforced an inclusive same-day through 365-day booking window for departures and returns in the UI and server. Nearby dates, URL state, and service states remain. |
+| 2026-07-18 | P1.1 | In progress | Pending | Suggested the nearest earlier and later operating dates for empty exact-date searches and made each suggestion searchable. URL state and service states remain. |

--- a/__tests__/app/actions.test.ts
+++ b/__tests__/app/actions.test.ts
@@ -190,7 +190,10 @@ describe('deleteCityGuideAction authorization and execution', () => {
 });
 
 describe('searchFlightsAction', () => {
-    beforeEach(() => jest.clearAllMocks());
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedFlightScheduleFindMany.mockResolvedValue([]);
+    });
     afterEach(() => jest.useRealTimers());
 
     it('filters flights by the selected origin and destination without date', async () => {
@@ -204,7 +207,8 @@ describe('searchFlightsAction', () => {
         expect(mockedFlightFindMany).toHaveBeenCalledWith(
             expect.objectContaining({ where: { from: 'Seattle, USA', to: 'Detroit, USA' } })
         );
-        expect(result).toBe(flights);
+        expect(result).toEqual({ flights, nearbyDates: [] });
+        expect(mockedFlightScheduleFindMany).not.toHaveBeenCalled();
     });
 
     it('triggers lazy generation and queries by date when departureDateStr is provided', async () => {
@@ -222,6 +226,7 @@ describe('searchFlightsAction', () => {
             where: {
                 from: 'Seattle, USA',
                 to: 'Detroit, USA',
+                status: { not: 'CANCELLED' },
                 departureDate: {
                     gte: new Date('2026-06-25T00:00:00.000Z'),
                     lte: new Date('2026-06-25T23:59:59.999Z')
@@ -229,7 +234,61 @@ describe('searchFlightsAction', () => {
             },
             orderBy: { departureDate: 'asc' }
         });
-        expect(result).toBe(flights);
+        expect(result).toEqual({ flights, nearbyDates: [] });
+    });
+
+    it('suggests the nearest operating dates when the exact date has no flights', async () => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-07-14T12:00:00.000Z'));
+        mockedFlightFindMany
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([
+                {
+                    flightNumber: 'CA101',
+                    departureDate: new Date('2026-07-15T08:00:00.000Z'),
+                },
+            ]);
+        mockedFlightScheduleFindMany.mockResolvedValue([
+            { flightNumber: 'CA101', departureTime: '08:00', daysOfWeek: [1, 3, 5] },
+        ]);
+        mockGenerateFlightsForDate.mockResolvedValue([]);
+
+        const result = await searchFlightsAction(
+            'Seattle, USA',
+            'Detroit, USA',
+            '2026-07-16',
+        );
+
+        expect(mockedFlightScheduleFindMany).toHaveBeenCalledWith({
+            where: {
+                isActive: true,
+                from: 'Seattle, USA',
+                to: 'Detroit, USA',
+            },
+            select: {
+                flightNumber: true,
+                departureTime: true,
+                daysOfWeek: true,
+            },
+        });
+        expect(mockedFlightFindMany).toHaveBeenNthCalledWith(2, {
+            where: {
+                from: 'Seattle, USA',
+                to: 'Detroit, USA',
+                status: 'CANCELLED',
+                departureDate: {
+                    gte: new Date('2026-07-14T00:00:00.000Z'),
+                    lte: new Date('2027-07-14T23:59:59.999Z'),
+                },
+            },
+            select: {
+                flightNumber: true,
+                departureDate: true,
+            },
+        });
+        expect(result).toEqual({
+            flights: [],
+            nearbyDates: ['2026-07-17'],
+        });
     });
 
     it('excludes already-departed flights when searching today', async () => {
@@ -244,6 +303,7 @@ describe('searchFlightsAction', () => {
             where: {
                 from: 'Seattle, USA',
                 to: 'Detroit, USA',
+                status: { not: 'CANCELLED' },
                 departureDate: {
                     gt: now,
                     lte: new Date('2026-07-14T23:59:59.999Z'),

--- a/__tests__/components/flightBookingForm.test.tsx
+++ b/__tests__/components/flightBookingForm.test.tsx
@@ -13,6 +13,11 @@ jest.mock('@/app/actions', () => ({
 const mockSearch = searchFlightsAction as jest.Mock;
 const mockBook = bookFlightAction as jest.Mock;
 
+const searchSuccess = (flights: unknown[], nearbyDates: string[] = []) => ({
+    flights,
+    nearbyDates,
+});
+
 const routes = [
     { from: 'Seattle, USA', to: 'Detroit, USA', nextOperatingDate: '2026-07-15' },
     { from: 'Seattle, USA', to: 'Tokyo, Japan', nextOperatingDate: '2026-07-16' },
@@ -158,7 +163,7 @@ describe('FlightBookingForm', () => {
     });
 
     it('searches using the selected origin and destination', async () => {
-        mockSearch.mockResolvedValue(mockFlights);
+        mockSearch.mockResolvedValue(searchSuccess(mockFlights));
 
         renderForm();
         fireEvent.click(screen.getByText('Find your trip'));
@@ -254,8 +259,10 @@ describe('FlightBookingForm', () => {
         expect(mockSearch).not.toHaveBeenCalled();
     });
 
-    it('shows a no-results message when no flights match the route', async () => {
-        mockSearch.mockResolvedValue([]);
+    it('searches a suggested nearby date when no flights match the exact date', async () => {
+        mockSearch
+            .mockResolvedValueOnce(searchSuccess([], ['2026-07-15', '2026-07-17']))
+            .mockResolvedValueOnce(searchSuccess(mockFlights));
 
         renderForm();
         fireEvent.click(screen.getByText('Find your trip'));
@@ -263,6 +270,49 @@ describe('FlightBookingForm', () => {
         await waitFor(() => {
             expect(screen.getByText(/No flights found/i)).toBeInTheDocument();
         });
+        expect(screen.queryByText('Available Flights')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Wed, Jul 15' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Available Flights')).toBeInTheDocument();
+        });
+        expect(screen.getByRole('heading', { name: 'Available Flights' })).toHaveFocus();
+        expect(mockSearch).toHaveBeenLastCalledWith(
+            'Seattle, USA',
+            'Detroit, USA',
+            '2026-07-15',
+            '2026-07-22',
+        );
+    });
+
+    it('removes nearby suggestions when the route changes', async () => {
+        mockSearch.mockResolvedValue(searchSuccess([], ['2026-07-15', '2026-07-17']));
+
+        renderForm();
+        fireEvent.click(screen.getByText('Find your trip'));
+        expect(await screen.findByLabelText('Nearby operating dates')).toBeInTheDocument();
+
+        fireEvent.change(screen.getByLabelText('From'), { target: { value: 'New York, USA' } });
+
+        expect(screen.queryByLabelText('Nearby operating dates')).not.toBeInTheDocument();
+    });
+
+    it('discards a stale search response after the criteria change', async () => {
+        let resolveSearch: (result: ReturnType<typeof searchSuccess>) => void = () => undefined;
+        mockSearch.mockReturnValue(new Promise((resolve) => {
+            resolveSearch = resolve;
+        }));
+
+        renderForm();
+        fireEvent.click(screen.getByText('Find your trip'));
+        fireEvent.change(screen.getByLabelText('To'), { target: { value: 'Tokyo, Japan' } });
+
+        await act(async () => {
+            resolveSearch(searchSuccess([], ['2026-07-15', '2026-07-17']));
+        });
+
+        expect(screen.queryByLabelText('Nearby operating dates')).not.toBeInTheDocument();
         expect(screen.queryByText('Available Flights')).not.toBeInTheDocument();
     });
 
@@ -309,7 +359,7 @@ describe('FlightBookingForm', () => {
     });
 
     it('redirects to the book page when "Book Now" is clicked', async () => {
-        mockSearch.mockResolvedValue(mockFlights);
+        mockSearch.mockResolvedValue(searchSuccess(mockFlights));
 
         renderForm();
         fireEvent.click(screen.getByText('Find your trip'));
@@ -346,7 +396,7 @@ describe('FlightBookingForm', () => {
     });
 
     it('filters out cancelled flights and exposes interactive price, airline and sorting controls', async () => {
-        mockSearch.mockResolvedValue(mockEnhancedFlights);
+        mockSearch.mockResolvedValue(searchSuccess(mockEnhancedFlights));
 
         renderForm();
         fireEvent.click(screen.getByText('Find your trip'));

--- a/__tests__/lib/flightSearch.test.ts
+++ b/__tests__/lib/flightSearch.test.ts
@@ -1,4 +1,4 @@
-import { buildFlightRoutes } from '@/lib/flightSearch';
+import { buildFlightRoutes, findNearbyOperatingDates } from '@/lib/flightSearch';
 
 describe('buildFlightRoutes', () => {
     it('uses the nearest future operating date across active route schedules', () => {
@@ -48,5 +48,46 @@ describe('buildFlightRoutes', () => {
         ], new Date('2026-07-14T12:00:00.000Z'));
 
         expect(routes[0]?.nextOperatingDate).toBe('2026-07-17');
+    });
+});
+
+describe('findNearbyOperatingDates', () => {
+    it('returns the nearest earlier and later operating dates', () => {
+        expect(findNearbyOperatingDates([
+            { flightNumber: 'CA101', departureTime: '08:00', daysOfWeek: [1, 3, 5] },
+        ], '2026-07-16', new Date('2026-07-14T12:00:00.000Z'))).toEqual([
+            '2026-07-15',
+            '2026-07-17',
+        ]);
+    });
+
+    it('excludes past and already-departed candidates', () => {
+        expect(findNearbyOperatingDates([
+            { flightNumber: 'CA101', departureTime: '08:00', daysOfWeek: [2, 4] },
+        ], '2026-07-15', new Date('2026-07-14T12:00:00.000Z'))).toEqual([
+            '2026-07-16',
+        ]);
+    });
+
+    it('does not suggest dates beyond the booking window', () => {
+        expect(findNearbyOperatingDates([
+            { flightNumber: 'CA101', departureTime: '08:00', daysOfWeek: [0, 1, 2, 3, 4, 5, 6] },
+        ], '2027-07-14', new Date('2026-07-14T12:00:00.000Z'))).toEqual([
+            '2027-07-13',
+        ]);
+    });
+
+    it('skips operating dates whose scheduled occurrence is cancelled', () => {
+        expect(findNearbyOperatingDates([
+            { flightNumber: 'CA101', departureTime: '08:00', daysOfWeek: [1, 3, 5] },
+        ], '2026-07-16', new Date('2026-07-01T12:00:00.000Z'), [
+            {
+                flightNumber: 'CA101',
+                departureDate: new Date('2026-07-15T08:00:00.000Z'),
+            },
+        ])).toEqual([
+            '2026-07-13',
+            '2026-07-17',
+        ]);
     });
 });

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -14,7 +14,8 @@ import { lockFlightForUpdate } from '@/lib/flightLock';
 import { updateFlightSeatingLayout } from '@/lib/FlightSeatLayoutService';
 import { actionValidationFailure } from '@/lib/actionResult';
 import { parsePriceToCents } from '@/lib/bookingPricing';
-import { buildFlightRoutes } from '@/lib/flightSearch';
+import { buildFlightRoutes, findNearbyOperatingDates } from '@/lib/flightSearch';
+import { bookingWindowIsoDates } from '@/lib/dates';
 import {
     bookingRequestSchema,
     cityGuideSchema,
@@ -82,10 +83,11 @@ export async function searchFlightsAction(
     ({ from, to, departureDate: departureDateStr } = parsed.data);
 
     if (!departureDateStr) {
-        return await prisma.flight.findMany({
+        const flights = await prisma.flight.findMany({
             where: { from, to },
             orderBy: { departureDate: 'asc' },
         });
+        return { flights, nearbyDates: [] };
     }
 
     const searchDate = new Date(departureDateStr);
@@ -100,10 +102,11 @@ export async function searchFlightsAction(
         ? { gt: now }
         : { gte: startOfDay };
 
-    return await prisma.flight.findMany({
+    const flights = await prisma.flight.findMany({
         where: {
             from,
             to,
+            status: { not: 'CANCELLED' },
             departureDate: {
                 ...departureLowerBound,
                 lte: endOfDay
@@ -111,6 +114,49 @@ export async function searchFlightsAction(
         },
         orderBy: { departureDate: 'asc' },
     });
+
+    if (flights.length > 0) return { flights, nearbyDates: [] };
+
+    const { earliestDate, latestDate } = bookingWindowIsoDates(now);
+    const [schedules, cancelledFlights] = await Promise.all([
+        prisma.flightSchedule.findMany({
+            where: {
+                isActive: true,
+                from,
+                to,
+            },
+            select: {
+                flightNumber: true,
+                departureTime: true,
+                daysOfWeek: true,
+            },
+        }),
+        prisma.flight.findMany({
+            where: {
+                from,
+                to,
+                status: 'CANCELLED',
+                departureDate: {
+                    gte: new Date(`${earliestDate}T00:00:00.000Z`),
+                    lte: new Date(`${latestDate}T23:59:59.999Z`),
+                },
+            },
+            select: {
+                flightNumber: true,
+                departureDate: true,
+            },
+        }),
+    ]);
+
+    return {
+        flights,
+        nearbyDates: findNearbyOperatingDates(
+            schedules,
+            departureDateStr,
+            now,
+            cancelledFlights,
+        ),
+    };
 }
 
 export async function getFlightRoutesAction() {

--- a/components/ui/flightBookingForm.tsx
+++ b/components/ui/flightBookingForm.tsx
@@ -45,6 +45,15 @@ function millisecondsUntilNextUtcDay(referenceDate = new Date()): number {
     return nextUtcDay - referenceDate.getTime();
 }
 
+function formatSuggestedDate(dateString: string): string {
+    return new Intl.DateTimeFormat('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+    }).format(new Date(`${dateString}T00:00:00.000Z`));
+}
+
 const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     routes = [],
     minimumDepartureDate = earliestBookableDateIso(),
@@ -55,6 +64,8 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
         latestDate: maximumDepartureDate,
     });
     const latestBookingDateRef = useRef(maximumDepartureDate);
+    const resultsHeadingRef = useRef<HTMLHeadingElement>(null);
+    const searchRequestIdRef = useRef(0);
     // Origins are the distinct departure cities; destinations depend on the
     // selected origin so only reachable routes can be chosen.
     const origins = useMemo(() => Array.from(new Set(routes.map((r) => r.from))), [routes]);
@@ -78,6 +89,7 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     const [isOneWay, setIsOneWay] = useState(false);
     const [isSearching, setIsSearching] = useState(false);
     const [searchResults, setSearchResults] = useState<Flight[] | null>(null);
+    const [nearbyDates, setNearbyDates] = useState<string[]>([]);
     const [bookingState, setBookingState] = useState<BookingState>({ status: 'idle' });
 
     // Interactive Filters & Sorting States
@@ -85,7 +97,17 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     const [maxPrice, setMaxPrice] = useState<number>(0);
     const [selectedAirlines, setSelectedAirlines] = useState<string[]>([]);
 
+    const clearEmptySearchState = () => {
+        searchRequestIdRef.current += 1;
+        setIsSearching(false);
+        setNearbyDates([]);
+        setSearchResults((currentResults) => (
+            currentResults?.length === 0 ? null : currentResults
+        ));
+    };
+
     const handleTripTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        clearEmptySearchState();
         const isChangingToOneWay = e.target.value === 'one-way';
         setIsOneWay(isChangingToOneWay);
         // Clear only validation that depends on a return date, which no longer
@@ -100,9 +122,56 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
         }
     };
 
+    const performSearch = async (
+        selectedDepartureDate: string,
+        selectedReturnDate: string,
+    ) => {
+        const requestId = searchRequestIdRef.current + 1;
+        searchRequestIdRef.current = requestId;
+        setSearchResults(null);
+        setNearbyDates([]);
+        setBookingState({ status: 'idle' });
+
+        setIsSearching(true);
+        try {
+            const results = await searchFlightsAction(
+                fromLocation,
+                toLocation,
+                selectedDepartureDate,
+                isOneWay ? undefined : selectedReturnDate,
+            );
+            if (requestId !== searchRequestIdRef.current) return;
+            if (isActionValidationFailure(results)) {
+                const clearOnOneWay = Boolean(
+                    results.error.fields.returnDate?.includes(results.error.message)
+                    || results.error.message === DEPARTURE_REQUIRED_WITH_RETURN_MESSAGE
+                );
+                setBookingState({
+                    status: 'error',
+                    message: results.error.message,
+                    clearOnOneWay,
+                });
+                return;
+            }
+            setSearchResults(results.flights);
+            setNearbyDates(results.nearbyDates);
+        } catch (error) {
+            if (requestId === searchRequestIdRef.current) {
+                setBookingState({ status: 'error', message: 'Unable to search for flights right now.' });
+            }
+        } finally {
+            if (requestId === searchRequestIdRef.current) {
+                setIsSearching(false);
+            }
+        }
+    };
+
     const handleSearch = async (e: React.FormEvent) => {
         e.preventDefault();
+        searchRequestIdRef.current += 1;
+        setIsSearching(false);
         setSearchResults(null);
+        setNearbyDates([]);
         setBookingState({ status: 'idle' });
 
         if (departureDate && departureDate < bookingWindow.earliestDate) {
@@ -144,32 +213,19 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
             return;
         }
 
-        setIsSearching(true);
-        try {
-            const results = await searchFlightsAction(
-                fromLocation,
-                toLocation,
-                departureDate,
-                isOneWay ? undefined : returnDate,
+        await performSearch(departureDate, returnDate);
+    };
+
+    const handleNearbyDateSearch = async (suggestedDate: string) => {
+        const suggestedReturnDate = isOneWay
+            ? ''
+            : clampToMaximumDate(
+                addDaysToIsoDate(suggestedDate, 7),
+                latestBookingDateRef.current,
             );
-            if (isActionValidationFailure(results)) {
-                const clearOnOneWay = Boolean(
-                    results.error.fields.returnDate?.includes(results.error.message)
-                    || results.error.message === DEPARTURE_REQUIRED_WITH_RETURN_MESSAGE
-                );
-                setBookingState({
-                    status: 'error',
-                    message: results.error.message,
-                    clearOnOneWay,
-                });
-                return;
-            }
-            setSearchResults(results);
-        } catch (error) {
-            setBookingState({ status: 'error', message: 'Unable to search for flights right now.' });
-        } finally {
-            setIsSearching(false);
-        }
+        setDepartureDate(suggestedDate);
+        setReturnDate(suggestedReturnDate);
+        await performSearch(suggestedDate, suggestedReturnDate);
     };
 
     // When the origin changes, keep the destination valid for the new origin.
@@ -217,6 +273,12 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                 : clampToMaximumDate(proposedReturnDate, latestBookingDateRef.current)
         );
     }, [departureDate, isOneWay]);
+
+    useEffect(() => {
+        if (searchResults && searchResults.length > 0) {
+            resultsHeadingRef.current?.focus();
+        }
+    }, [searchResults]);
 
     // Helper to parse price string to number safely (handles $ and commas)
     const parsePrice = (priceStr?: string): number => {
@@ -338,7 +400,10 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
 
                 <div className="fields-container">
                     <label htmlFor="from">From</label>
-                    <select id="from" name="from" value={fromLocation} onChange={e => setFromLocation(e.target.value)}>
+                    <select id="from" name="from" value={fromLocation} onChange={(e) => {
+                        setFromLocation(e.target.value);
+                        clearEmptySearchState();
+                    }}>
                         {origins.map((loc) => (
                             <option key={loc} value={loc}>{loc}</option>
                         ))}
@@ -347,7 +412,10 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
 
                 <div className="fields-container">
                     <label htmlFor="to">To</label>
-                    <select id="to" name="to" value={toLocation} onChange={e => setToLocation(e.target.value)}>
+                    <select id="to" name="to" value={toLocation} onChange={(e) => {
+                        setToLocation(e.target.value);
+                        clearEmptySearchState();
+                    }}>
                         {destinations.map((loc) => (
                             <option key={loc} value={loc}>{loc}</option>
                         ))}
@@ -364,7 +432,10 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                             min={bookingWindow.earliestDate}
                             max={bookingWindow.latestDate}
                             value={departureDate}
-                            onChange={e => setDepartureDate(e.target.value)}
+                            onChange={(e) => {
+                                setDepartureDate(e.target.value);
+                                clearEmptySearchState();
+                            }}
                         />
                     </div>
                     <div style={{ marginLeft: '12px' }}
@@ -379,7 +450,10 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                             min={departureDate || bookingWindow.earliestDate}
                             max={bookingWindow.latestDate}
                             value={returnDate}
-                            onChange={(e) => setReturnDate(e.target.value)}
+                            onChange={(e) => {
+                                setReturnDate(e.target.value);
+                                clearEmptySearchState();
+                            }}
                             disabled={isOneWay}
                         />
                     </div>
@@ -442,7 +516,40 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                                     color: 'rgba(255, 255, 255, 0.6)',
                                     marginTop: '24px'
                                 }}>
-                                    No flights found for this route. Try a different origin or destination.
+                                    <p style={{ margin: 0 }}>
+                                        No flights found for your selected date.
+                                    </p>
+                                    {nearbyDates.length > 0 && (
+                                        <div
+                                            aria-label="Nearby operating dates"
+                                            style={{ marginTop: '16px' }}
+                                        >
+                                            <p style={{ margin: '0 0 10px', color: 'rgba(255, 255, 255, 0.8)' }}>
+                                                Try a nearby date:
+                                            </p>
+                                            <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: '10px' }}>
+                                                {nearbyDates.map((date) => (
+                                                    <button
+                                                        key={date}
+                                                        type="button"
+                                                        disabled={isSearching}
+                                                        onClick={() => void handleNearbyDateSearch(date)}
+                                                        style={{
+                                                            border: '1px solid rgba(192, 132, 252, 0.7)',
+                                                            borderRadius: '8px',
+                                                            background: 'rgba(192, 132, 252, 0.12)',
+                                                            color: '#e9d5ff',
+                                                            padding: '8px 12px',
+                                                            cursor: 'pointer',
+                                                            fontWeight: 600,
+                                                        }}
+                                                    >
+                                                        {formatSuggestedDate(date)}
+                                                    </button>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    )}
                                 </div>
                             )}
                         </div>
@@ -555,7 +662,14 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                                 boxShadow: '0 4px 20px rgba(0,0,0,0.1)'
                             }}>
                                 <div>
-                                    <h2 className="text-2xl font-bold" style={{ fontSize: '1.25rem', color: '#c084fc', margin: 0, display: 'inline-block' }}>Available Flights</h2>
+                                    <h2
+                                        ref={resultsHeadingRef}
+                                        tabIndex={-1}
+                                        className="text-2xl font-bold"
+                                        style={{ fontSize: '1.25rem', color: '#c084fc', margin: 0, display: 'inline-block' }}
+                                    >
+                                        Available Flights
+                                    </h2>
                                     <span style={{ fontSize: '0.9rem', color: 'rgba(255,255,255,0.5)', marginLeft: '12px' }}>
                                         ({filteredAndSortedResults.length} {filteredAndSortedResults.length === 1 ? 'flight' : 'flights'} found)
                                     </span>

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -9,7 +9,9 @@ test.describe('Flight search', () => {
 
     await page.getByRole('button', { name: 'Find your trip' }).click();
 
-    await expect(page.getByRole('heading', { name: 'Available Flights' })).toBeVisible();
+    const resultsHeading = page.getByRole('heading', { name: 'Available Flights' });
+    await expect(resultsHeading).toBeVisible();
+    await expect(resultsHeading).toBeFocused();
     await expect(page.getByRole('link', { name: 'Book Now' }).first()).toBeVisible();
   });
 
@@ -88,5 +90,30 @@ test.describe('Flight search', () => {
     await expect(page.getByRole('alert').filter({
       hasText: 'Departure date is required when a return date is provided.',
     })).toHaveCount(0);
+  });
+
+  test('No exact flight offers a nearby operating date that can be searched', async ({ page }) => {
+    await page.goto('/');
+
+    const departure = page.getByLabel('Depart');
+    const exactOperatingDate = await departure.inputValue();
+    const noServiceDate = new Date(`${exactOperatingDate}T00:00:00.000Z`);
+    noServiceDate.setUTCDate(noServiceDate.getUTCDate() + 1);
+    await departure.fill(noServiceDate.toISOString().slice(0, 10));
+
+    await page.getByRole('button', { name: 'Find your trip' }).click();
+
+    await expect(page.getByText(/No flights found/i)).toBeVisible();
+    const suggestion = page
+      .getByLabel('Nearby operating dates')
+      .getByRole('button')
+      .first();
+    await expect(suggestion).toBeVisible();
+    await suggestion.click();
+
+    const resultsHeading = page.getByRole('heading', { name: 'Available Flights' });
+    await expect(resultsHeading).toBeVisible();
+    await expect(resultsHeading).toBeFocused();
+    await expect(page.getByRole('link', { name: 'Book Now' }).first()).toBeVisible();
   });
 });

--- a/lib/flightSearch.ts
+++ b/lib/flightSearch.ts
@@ -1,8 +1,21 @@
+import { addDaysToIsoDate, bookingWindowIsoDates } from '@/lib/dates';
+
 export interface FlightScheduleSummary {
     from: string;
     to: string;
     departureTime: string;
     daysOfWeek: number[];
+}
+
+export interface OperatingScheduleSummary {
+    flightNumber: string;
+    departureTime: string;
+    daysOfWeek: number[];
+}
+
+export interface CancelledFlightSummary {
+    flightNumber: string;
+    departureDate: Date;
 }
 
 export interface FlightRoute {
@@ -67,4 +80,68 @@ export function buildFlightRoutes(
     }
 
     return Array.from(routes.values(), ({ route }) => route);
+}
+
+function hasFutureDepartureOnDate(
+    schedules: OperatingScheduleSummary[],
+    dateString: string,
+    now: Date,
+    cancelledDepartureKeys: ReadonlySet<string>,
+): boolean {
+    const day = new Date(`${dateString}T00:00:00.000Z`).getUTCDay();
+
+    return schedules.some((schedule) => {
+        if (!schedule.daysOfWeek.includes(day)) return false;
+        const departure = new Date(`${dateString}T${schedule.departureTime}:00Z`);
+        if (Number.isNaN(departure.getTime())) return false;
+        const departureKey = `${schedule.flightNumber}\u0000${departure.toISOString()}`;
+        return departure > now
+            && !cancelledDepartureKeys.has(departureKey);
+    });
+}
+
+export function findNearbyOperatingDates(
+    schedules: OperatingScheduleSummary[],
+    requestedDate: string,
+    now = new Date(),
+    cancelledFlights: CancelledFlightSummary[] = [],
+): string[] {
+    const { earliestDate, latestDate } = bookingWindowIsoDates(now);
+    const cancelledDepartureKeys = new Set(cancelledFlights.map((flight) => (
+        `${flight.flightNumber}\u0000${flight.departureDate.toISOString()}`
+    )));
+    let earlierDate: string | undefined;
+    let laterDate: string | undefined;
+
+    for (let offset = 1; offset <= 365 && (!earlierDate || !laterDate); offset += 1) {
+        const earlierCandidate = addDaysToIsoDate(requestedDate, -offset);
+        if (
+            !earlierDate
+            && earlierCandidate >= earliestDate
+            && hasFutureDepartureOnDate(
+                schedules,
+                earlierCandidate,
+                now,
+                cancelledDepartureKeys,
+            )
+        ) {
+            earlierDate = earlierCandidate;
+        }
+
+        const laterCandidate = addDaysToIsoDate(requestedDate, offset);
+        if (
+            !laterDate
+            && laterCandidate <= latestDate
+            && hasFutureDepartureOnDate(
+                schedules,
+                laterCandidate,
+                now,
+                cancelledDepartureKeys,
+            )
+        ) {
+            laterDate = laterCandidate;
+        }
+    }
+
+    return [earlierDate, laterDate].filter((date): date is string => Boolean(date));
 }


### PR DESCRIPTION
## Summary

- suggest the nearest earlier and later operating dates when an exact-date search has no available flights
- let travelers select a suggestion and immediately rerun the search, with focus moved to the visible results heading
- discard stale in-flight responses when criteria change and exclude canceled exact or suggested occurrences
- update the P1.1 roadmap progress and add unit, action, component, and browser regression coverage

## Why

This completes the next thin vertical slice of P1.1 by giving travelers a useful recovery path when their chosen date has no service, instead of leaving them at a dead end.

## Validation

- Jest: 52 suites, 389 tests passed
- TypeScript: passed
- ESLint: passed with 8 known pre-existing warnings
- independent production build: passed
- Docker Compose runtime and homepage HTTP 200: passed
- Playwright search flow: 3/3 passed
- responsive UI review: approved at phone, tablet, and desktop widths
- independent verifier and final code review: approved
