### PR TITLE
feat(search): preserve criteria in result URLs

### DIFF
--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -126,7 +126,7 @@ journey succeeds.
   inclusive; interim UTC day boundary).
 - [x] Suggest the nearest earlier and later operating dates when no exact match
   exists.
-- [ ] Preserve search criteria in URL parameters.
+- [x] Preserve search criteria in URL parameters.
 - [ ] Add loading, empty, failure, retry, and degraded-service states.
 - [ ] Base the earliest selectable date and the past-departure rule on the origin
   airport's local day once airport timezone data exists (interim: UTC via
@@ -510,3 +510,4 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-17 | P1.1 | In progress | #46 | Rejected past departures and invalid return ordering in the UI and server, and excluded already-departed inventory from same-day results. Booking windows and later search slices remain. |
 | 2026-07-18 | P1.1 | In progress | #47 | Enforced an inclusive same-day through 365-day booking window for departures and returns in the UI and server. Nearby dates, URL state, and service states remain. |
 | 2026-07-18 | P1.1 | In progress | #48 | Suggested the nearest earlier and later operating dates for empty exact-date searches and made each suggestion searchable. URL state and service states remain. |
+| 2026-07-18 | P1.1 | In progress | Pending | Preserved route, dates, and trip type in shareable result URLs, restored results on refresh, and safely ignored invalid shared criteria. Service states remain. |

--- a/REAL_WORLD_ROADMAP.md
+++ b/REAL_WORLD_ROADMAP.md
@@ -510,4 +510,4 @@ Add one row when work starts, becomes blocked, or completes.
 | 2026-07-17 | P1.1 | In progress | #46 | Rejected past departures and invalid return ordering in the UI and server, and excluded already-departed inventory from same-day results. Booking windows and later search slices remain. |
 | 2026-07-18 | P1.1 | In progress | #47 | Enforced an inclusive same-day through 365-day booking window for departures and returns in the UI and server. Nearby dates, URL state, and service states remain. |
 | 2026-07-18 | P1.1 | In progress | #48 | Suggested the nearest earlier and later operating dates for empty exact-date searches and made each suggestion searchable. URL state and service states remain. |
-| 2026-07-18 | P1.1 | In progress | Pending | Preserved route, dates, and trip type in shareable result URLs, restored results on refresh, and safely ignored invalid shared criteria. Service states remain. |
+| 2026-07-18 | P1.1 | In progress | #49 | Preserved route, dates, and trip type in shareable result URLs, restored results on refresh, and safely ignored invalid shared criteria. Service states remain. |

--- a/__tests__/components/flightBookingForm.test.tsx
+++ b/__tests__/components/flightBookingForm.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom';
 import FlightBookingForm from '@/components/ui/flightBookingForm';
 import { bookFlightAction, searchFlightsAction } from '@/app/actions';
+import type { FlightSearchCriteria } from '@/lib/flightSearchUrl';
 
 // Mock server actions
 jest.mock('@/app/actions', () => ({
@@ -85,11 +86,12 @@ const mockEnhancedFlights = [
     }
 ];
 
-const renderForm = () => render(
+const renderForm = (initialSearch?: FlightSearchCriteria) => render(
     <FlightBookingForm
         routes={routes}
         minimumDepartureDate="2026-07-14"
         maximumDepartureDate="2027-07-14"
+        initialSearch={initialSearch}
     />
 );
 
@@ -97,6 +99,7 @@ describe('FlightBookingForm', () => {
     beforeEach(() => {
         jest.useFakeTimers().setSystemTime(new Date('2026-07-14T12:00:00.000Z'));
         jest.clearAllMocks();
+        window.history.replaceState(null, '', '/');
     });
     afterEach(() => jest.useRealTimers());
 
@@ -178,6 +181,74 @@ describe('FlightBookingForm', () => {
             expect.any(String),
             expect.any(String),
         );
+    });
+
+    it('writes searched criteria to a shareable URL', async () => {
+        mockSearch.mockResolvedValue(searchSuccess(mockFlights));
+
+        renderForm();
+        fireEvent.click(screen.getByText('Find your trip'));
+
+        await waitFor(() => expect(screen.getByText('Available Flights')).toBeInTheDocument());
+        const params = new URLSearchParams(window.location.search);
+        expect(params.get('from')).toBe('Seattle, USA');
+        expect(params.get('to')).toBe('Detroit, USA');
+        expect(params.get('depart')).toBe('2026-07-15');
+        expect(params.get('return')).toBe('2026-07-22');
+        expect(params.get('trip')).toBe('round-trip');
+    });
+
+    it('restores shared criteria and automatically reruns the search', async () => {
+        mockSearch.mockResolvedValue(searchSuccess(mockFlights));
+        const initialSearch: FlightSearchCriteria = {
+            from: 'New York, USA',
+            to: 'London, UK',
+            departureDate: '2026-07-20',
+            returnDate: '2026-07-27',
+            tripType: 'round-trip',
+        };
+
+        renderForm(initialSearch);
+
+        expect(screen.getByLabelText('From')).toHaveValue('New York, USA');
+        expect(screen.getByLabelText('To')).toHaveValue('London, UK');
+        expect(screen.getByLabelText('Depart')).toHaveValue('2026-07-20');
+        expect(screen.getByLabelText('Return')).toHaveValue('2026-07-27');
+        await waitFor(() => {
+            expect(mockSearch).toHaveBeenCalledWith(
+                'New York, USA',
+                'London, UK',
+                '2026-07-20',
+                '2026-07-27',
+            );
+        });
+        expect(await screen.findByText('Available Flights')).toBeInTheDocument();
+        expect(screen.getByLabelText('Depart')).toHaveValue('2026-07-20');
+    });
+
+    it('restores and reruns a route-only search without optional dates', async () => {
+        mockSearch.mockResolvedValue(searchSuccess(mockFlights));
+        const initialSearch: FlightSearchCriteria = {
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            departureDate: '',
+            returnDate: '',
+            tripType: 'round-trip',
+        };
+
+        renderForm(initialSearch);
+
+        expect(screen.getByLabelText('Depart')).toHaveValue('');
+        expect(screen.getByLabelText('Return')).toHaveValue('');
+        await waitFor(() => {
+            expect(mockSearch).toHaveBeenCalledWith(
+                'Seattle, USA',
+                'Detroit, USA',
+                '',
+                '',
+            );
+        });
+        expect(await screen.findByText('Available Flights')).toBeInTheDocument();
     });
 
     it('rejects past departures and returns before departure before searching', async () => {

--- a/__tests__/lib/flightSearchUrl.test.ts
+++ b/__tests__/lib/flightSearchUrl.test.ts
@@ -1,0 +1,134 @@
+import {
+    buildFlightSearchUrl,
+    parseFlightSearchParams,
+} from '@/lib/flightSearchUrl';
+
+const routes = [
+    { from: 'Seattle, USA', to: 'Detroit, USA', nextOperatingDate: '2026-07-15' },
+    { from: 'New York, USA', to: 'London, UK', nextOperatingDate: '2026-07-18' },
+];
+
+const bookingWindow = {
+    earliestDate: '2026-07-14',
+    latestDate: '2027-07-14',
+};
+
+describe('parseFlightSearchParams', () => {
+    it('restores valid round-trip criteria', () => {
+        expect(parseFlightSearchParams({
+            from: 'New York, USA',
+            to: 'London, UK',
+            depart: '2026-07-18',
+            return: '2026-07-25',
+            trip: 'round-trip',
+        }, routes, bookingWindow)).toEqual({
+            from: 'New York, USA',
+            to: 'London, UK',
+            departureDate: '2026-07-18',
+            returnDate: '2026-07-25',
+            tripType: 'round-trip',
+        });
+    });
+
+    it.each([
+        {
+            name: 'an unknown route',
+            params: {
+                from: 'Seattle, USA',
+                to: 'London, UK',
+                depart: '2026-07-18',
+                return: '2026-07-25',
+                trip: 'round-trip',
+            },
+        },
+        {
+            name: 'a departure outside the booking window',
+            params: {
+                from: 'Seattle, USA',
+                to: 'Detroit, USA',
+                depart: '2026-07-13',
+                return: '2026-07-20',
+                trip: 'round-trip',
+            },
+        },
+        {
+            name: 'a return before departure',
+            params: {
+                from: 'Seattle, USA',
+                to: 'Detroit, USA',
+                depart: '2026-07-20',
+                return: '2026-07-19',
+                trip: 'round-trip',
+            },
+        },
+    ])('rejects $name', ({ params }) => {
+        expect(parseFlightSearchParams(params, routes, bookingWindow)).toBeUndefined();
+    });
+
+    it('restores a round trip without an optional return date', () => {
+        expect(parseFlightSearchParams({
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            depart: '2026-07-20',
+            trip: 'round-trip',
+        }, routes, bookingWindow)).toEqual({
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            departureDate: '2026-07-20',
+            returnDate: '',
+            tripType: 'round-trip',
+        });
+    });
+
+    it('restores a route-only search without optional dates', () => {
+        expect(parseFlightSearchParams({
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            trip: 'round-trip',
+        }, routes, bookingWindow)).toEqual({
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            departureDate: '',
+            returnDate: '',
+            tripType: 'round-trip',
+        });
+    });
+});
+
+describe('buildFlightSearchUrl', () => {
+    it('builds a shareable round-trip URL', () => {
+        expect(buildFlightSearchUrl({
+            from: 'New York, USA',
+            to: 'London, UK',
+            departureDate: '2026-07-18',
+            returnDate: '2026-07-25',
+            tripType: 'round-trip',
+        }, '/')).toBe(
+            '/?from=New+York%2C+USA&to=London%2C+UK&depart=2026-07-18&return=2026-07-25&trip=round-trip'
+        );
+    });
+
+    it('omits the return date from a one-way URL', () => {
+        expect(buildFlightSearchUrl({
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            departureDate: '2026-07-20',
+            returnDate: '',
+            tripType: 'one-way',
+        }, '/')).toBe(
+            '/?from=Seattle%2C+USA&to=Detroit%2C+USA&depart=2026-07-20&trip=one-way'
+        );
+    });
+
+    it('omits empty optional dates from a route-only URL', () => {
+        expect(buildFlightSearchUrl({
+            from: 'Seattle, USA',
+            to: 'Detroit, USA',
+            departureDate: '',
+            returnDate: '',
+            tripType: 'round-trip',
+        }, '/')).toBe(
+            '/?from=Seattle%2C+USA&to=Detroit%2C+USA&trip=round-trip'
+        );
+    });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,19 +2,36 @@ import React from "react";
 import FlightBookingForm from "../components/ui/flightBookingForm";
 import { getFlightRoutesAction } from "./actions";
 import { bookingWindowIsoDates } from "@/lib/dates";
+import {
+  parseFlightSearchParams,
+  type FlightSearchParamRecord,
+} from "@/lib/flightSearchUrl";
 
 // Reads live flight inventory from the DB, so render per-request rather than
 // statically prerendering at build time (which would need a database).
 export const dynamic = 'force-dynamic';
 
-export default async function Home() {
-  const routes = await getFlightRoutesAction();
+interface HomeProps {
+  searchParams: Promise<FlightSearchParamRecord>;
+}
+
+export default async function Home({ searchParams }: HomeProps) {
+  const [routes, requestedSearch] = await Promise.all([
+    getFlightRoutesAction(),
+    searchParams,
+  ]);
   const { earliestDate, latestDate } = bookingWindowIsoDates();
+  const initialSearch = parseFlightSearchParams(
+    requestedSearch,
+    routes,
+    { earliestDate, latestDate },
+  );
   return (
     <FlightBookingForm
       routes={routes}
       minimumDepartureDate={earliestDate}
       maximumDepartureDate={latestDate}
+      initialSearch={initialSearch}
     />
   );
 }

--- a/components/ui/flightBookingForm.tsx
+++ b/components/ui/flightBookingForm.tsx
@@ -1,12 +1,16 @@
 "use client"
 
 import * as React from 'react'
-import { useState, useEffect, useMemo, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import Link from 'next/link'
 import { searchFlightsAction } from '@/app/actions'
 import { Flight } from '@prisma/client'
 import { isActionValidationFailure } from '@/lib/actionResult'
 import type { FlightRoute } from '@/lib/flightSearch'
+import {
+    buildFlightSearchUrl,
+    type FlightSearchCriteria,
+} from '@/lib/flightSearchUrl'
 import {
     DEPARTURE_AFTER_BOOKING_WINDOW_MESSAGE,
     RETURN_AFTER_BOOKING_WINDOW_MESSAGE,
@@ -20,6 +24,7 @@ interface FlightBookingFormProps {
     routes?: FlightRoute[];
     minimumDepartureDate?: string;
     maximumDepartureDate?: string;
+    initialSearch?: FlightSearchCriteria;
 }
 
 type BookingState = {
@@ -58,6 +63,7 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     routes = [],
     minimumDepartureDate = earliestBookableDateIso(),
     maximumDepartureDate = latestBookableDateIso(),
+    initialSearch,
 }) => {
     const [bookingWindow, setBookingWindow] = useState({
         earliestDate: minimumDepartureDate,
@@ -66,27 +72,41 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     const latestBookingDateRef = useRef(maximumDepartureDate);
     const resultsHeadingRef = useRef<HTMLHeadingElement>(null);
     const searchRequestIdRef = useRef(0);
+    const restoredSearchStartedRef = useRef(false);
+    const skipInitialRouteDefaultRef = useRef(Boolean(initialSearch));
+    const skipInitialReturnDefaultRef = useRef(Boolean(initialSearch));
     // Origins are the distinct departure cities; destinations depend on the
     // selected origin so only reachable routes can be chosen.
     const origins = useMemo(() => Array.from(new Set(routes.map((r) => r.from))), [routes]);
-    const [fromLocation, setFromLocation] = useState(origins[0] ?? '');
+    const [fromLocation, setFromLocation] = useState(
+        initialSearch?.from ?? origins[0] ?? ''
+    );
     const destinations = useMemo(
         () => routes.filter((r) => r.from === fromLocation).map((r) => r.to),
         [routes, fromLocation]
     );
-    const [toLocation, setToLocation] = useState(destinations[0] ?? '');
-    const initialDepartureDate = routes[0]?.nextOperatingDate ?? '';
+    const [toLocation, setToLocation] = useState(
+        initialSearch?.to ?? destinations[0] ?? ''
+    );
+    const initialDepartureDate = initialSearch?.departureDate
+        ?? routes.find(
+            ({ from, to }) => from === fromLocation && to === toLocation
+        )?.nextOperatingDate
+        ?? '';
     const [departureDate, setDepartureDate] = useState<string>(initialDepartureDate);
     const [returnDate, setReturnDate] = useState<string>(
-        initialDepartureDate
+        initialSearch?.returnDate
+        ?? (initialDepartureDate
             ? clampToMaximumDate(
                 addDaysToIsoDate(initialDepartureDate, 7),
                 bookingWindow.latestDate
             )
-            : ''
+            : '')
     );
     const [flightClass, setFlightClass] = useState('economy');
-    const [isOneWay, setIsOneWay] = useState(false);
+    const [isOneWay, setIsOneWay] = useState(
+        initialSearch?.tripType === 'one-way'
+    );
     const [isSearching, setIsSearching] = useState(false);
     const [searchResults, setSearchResults] = useState<Flight[] | null>(null);
     const [nearbyDates, setNearbyDates] = useState<string[]>([]);
@@ -122,9 +142,9 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
         }
     };
 
-    const performSearch = async (
-        selectedDepartureDate: string,
-        selectedReturnDate: string,
+    const performSearch = useCallback(async (
+        criteria: FlightSearchCriteria,
+        updateUrl = true,
     ) => {
         const requestId = searchRequestIdRef.current + 1;
         searchRequestIdRef.current = requestId;
@@ -135,10 +155,10 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
         setIsSearching(true);
         try {
             const results = await searchFlightsAction(
-                fromLocation,
-                toLocation,
-                selectedDepartureDate,
-                isOneWay ? undefined : selectedReturnDate,
+                criteria.from,
+                criteria.to,
+                criteria.departureDate,
+                criteria.tripType === 'one-way' ? undefined : criteria.returnDate,
             );
             if (requestId !== searchRequestIdRef.current) return;
             if (isActionValidationFailure(results)) {
@@ -153,6 +173,13 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                 });
                 return;
             }
+            if (updateUrl) {
+                window.history.replaceState(
+                    null,
+                    '',
+                    buildFlightSearchUrl(criteria, window.location.pathname),
+                );
+            }
             setSearchResults(results.flights);
             setNearbyDates(results.nearbyDates);
         } catch (error) {
@@ -164,7 +191,7 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                 setIsSearching(false);
             }
         }
-    };
+    }, []);
 
     const handleSearch = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -213,7 +240,13 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
             return;
         }
 
-        await performSearch(departureDate, returnDate);
+        await performSearch({
+            from: fromLocation,
+            to: toLocation,
+            departureDate,
+            returnDate: isOneWay ? '' : returnDate,
+            tripType: isOneWay ? 'one-way' : 'round-trip',
+        });
     };
 
     const handleNearbyDateSearch = async (suggestedDate: string) => {
@@ -225,7 +258,13 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
             );
         setDepartureDate(suggestedDate);
         setReturnDate(suggestedReturnDate);
-        await performSearch(suggestedDate, suggestedReturnDate);
+        await performSearch({
+            from: fromLocation,
+            to: toLocation,
+            departureDate: suggestedDate,
+            returnDate: suggestedReturnDate,
+            tripType: isOneWay ? 'one-way' : 'round-trip',
+        });
     };
 
     // When the origin changes, keep the destination valid for the new origin.
@@ -236,6 +275,10 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     }, [destinations, toLocation]);
 
     useEffect(() => {
+        if (skipInitialRouteDefaultRef.current) {
+            skipInitialRouteDefaultRef.current = false;
+            return;
+        }
         const route = routes.find(
             ({ from, to }) => from === fromLocation && to === toLocation
         );
@@ -264,6 +307,10 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     }, [bookingWindow.earliestDate, bookingWindow.latestDate]);
 
     useEffect(() => {
+        if (skipInitialReturnDefaultRef.current) {
+            skipInitialReturnDefaultRef.current = false;
+            return;
+        }
         const proposedReturnDate = departureDate
             ? addDaysToIsoDate(departureDate, 7)
             : '';
@@ -273,6 +320,12 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
                 : clampToMaximumDate(proposedReturnDate, latestBookingDateRef.current)
         );
     }, [departureDate, isOneWay]);
+
+    useEffect(() => {
+        if (!initialSearch || restoredSearchStartedRef.current) return;
+        restoredSearchStartedRef.current = true;
+        void performSearch(initialSearch, false);
+    }, [initialSearch, performSearch]);
 
     useEffect(() => {
         if (searchResults && searchResults.length > 0) {

--- a/components/ui/flightBookingForm.tsx
+++ b/components/ui/flightBookingForm.tsx
@@ -73,8 +73,6 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     const resultsHeadingRef = useRef<HTMLHeadingElement>(null);
     const searchRequestIdRef = useRef(0);
     const restoredSearchStartedRef = useRef(false);
-    const skipInitialRouteDefaultRef = useRef(Boolean(initialSearch));
-    const skipInitialReturnDefaultRef = useRef(Boolean(initialSearch));
     // Origins are the distinct departure cities; destinations depend on the
     // selected origin so only reachable routes can be chosen.
     const origins = useMemo(() => Array.from(new Set(routes.map((r) => r.from))), [routes]);
@@ -107,7 +105,10 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     const [isOneWay, setIsOneWay] = useState(
         initialSearch?.tripType === 'one-way'
     );
+    const previousRouteDefaultsRef = useRef({ fromLocation, toLocation });
+    const previousReturnDefaultsRef = useRef({ departureDate, isOneWay });
     const [isSearching, setIsSearching] = useState(false);
+    const [isSearchReady, setIsSearchReady] = useState(false);
     const [searchResults, setSearchResults] = useState<Flight[] | null>(null);
     const [nearbyDates, setNearbyDates] = useState<string[]>([]);
     const [bookingState, setBookingState] = useState<BookingState>({ status: 'idle' });
@@ -275,10 +276,13 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     }, [destinations, toLocation]);
 
     useEffect(() => {
-        if (skipInitialRouteDefaultRef.current) {
-            skipInitialRouteDefaultRef.current = false;
-            return;
-        }
+        const previousRoute = previousRouteDefaultsRef.current;
+        if (
+            previousRoute.fromLocation === fromLocation
+            && previousRoute.toLocation === toLocation
+        ) return;
+        previousRouteDefaultsRef.current = { fromLocation, toLocation };
+
         const route = routes.find(
             ({ from, to }) => from === fromLocation && to === toLocation
         );
@@ -307,10 +311,13 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     }, [bookingWindow.earliestDate, bookingWindow.latestDate]);
 
     useEffect(() => {
-        if (skipInitialReturnDefaultRef.current) {
-            skipInitialReturnDefaultRef.current = false;
-            return;
-        }
+        const previousDefaults = previousReturnDefaultsRef.current;
+        if (
+            previousDefaults.departureDate === departureDate
+            && previousDefaults.isOneWay === isOneWay
+        ) return;
+        previousReturnDefaultsRef.current = { departureDate, isOneWay };
+
         const proposedReturnDate = departureDate
             ? addDaysToIsoDate(departureDate, 7)
             : '';
@@ -326,6 +333,10 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
         restoredSearchStartedRef.current = true;
         void performSearch(initialSearch, false);
     }, [initialSearch, performSearch]);
+
+    useEffect(() => {
+        setIsSearchReady(true);
+    }, []);
 
     useEffect(() => {
         if (searchResults && searchResults.length > 0) {
@@ -535,7 +546,11 @@ const FlightBookingForm: React.FC<FlightBookingFormProps> = ({
     };
 
     return (
-        <div className="page-container home" style={{ minHeight: '100vh', padding: '40px 20px' }}>
+        <div
+            className="page-container home"
+            data-search-ready={isSearchReady ? 'true' : 'false'}
+            style={{ minHeight: '100vh', padding: '40px 20px' }}
+        >
             <div className="content" style={{
                 display: 'flex',
                 width: '100%',

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -15,6 +15,89 @@ test.describe('Flight search', () => {
     await expect(page.getByRole('link', { name: 'Book Now' }).first()).toBeVisible();
   });
 
+  test('Search criteria and results survive a refresh', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByLabel('From').selectOption({ label: 'New York, USA' });
+    await expect(page.getByLabel('To')).toHaveValue('London, UK');
+    const departureDate = await page.getByLabel('Depart').inputValue();
+    const returnDate = await page.getByLabel('Return').inputValue();
+
+    await page.getByRole('button', { name: 'Find your trip' }).click();
+    await expect(page.getByRole('heading', { name: 'Available Flights' })).toBeVisible();
+
+    await expect.poll(() => {
+      const params = new URL(page.url()).searchParams;
+      return {
+        from: params.get('from'),
+        to: params.get('to'),
+        depart: params.get('depart'),
+        returnDate: params.get('return'),
+        trip: params.get('trip'),
+      };
+    }).toEqual({
+      from: 'New York, USA',
+      to: 'London, UK',
+      depart: departureDate,
+      returnDate,
+      trip: 'round-trip',
+    });
+
+    await page.reload();
+
+    await expect(page.getByLabel('From')).toHaveValue('New York, USA');
+    await expect(page.getByLabel('To')).toHaveValue('London, UK');
+    await expect(page.getByLabel('Depart')).toHaveValue(departureDate);
+    await expect(page.getByLabel('Return')).toHaveValue(returnDate);
+    await expect(page.getByLabel('Round Trip')).toBeChecked();
+    await expect(page.getByRole('heading', { name: 'Available Flights' })).toBeVisible();
+  });
+
+  test('A round trip without an optional return date survives a refresh', async ({ page }) => {
+    await page.goto('/');
+
+    const departureDate = await page.getByLabel('Depart').inputValue();
+    await page.getByLabel('Return').fill('');
+    await page.getByRole('button', { name: 'Find your trip' }).click();
+    await expect(page.getByRole('heading', { name: 'Available Flights' })).toBeVisible();
+
+    await expect.poll(() => {
+      const params = new URL(page.url()).searchParams;
+      return {
+        depart: params.get('depart'),
+        returnDate: params.get('return'),
+        trip: params.get('trip'),
+      };
+    }).toEqual({
+      depart: departureDate,
+      returnDate: null,
+      trip: 'round-trip',
+    });
+
+    await page.reload();
+
+    await expect(page.getByLabel('Depart')).toHaveValue(departureDate);
+    await expect(page.getByLabel('Return')).toHaveValue('');
+    await expect(page.getByLabel('Round Trip')).toBeChecked();
+    await expect(page.getByRole('heading', { name: 'Available Flights' })).toBeVisible();
+  });
+
+  test('Invalid shared criteria fall back to valid defaults', async ({ page }) => {
+    await page.goto(
+      '/?from=Seattle%2C+USA&to=London%2C+UK&depart=2020-01-01&return=2020-01-08&trip=round-trip'
+    );
+
+    await expect.poll(async () => ({
+      from: await page.getByLabel('From').inputValue(),
+      to: await page.getByLabel('To').inputValue(),
+    })).not.toEqual({
+      from: 'Seattle, USA',
+      to: 'London, UK',
+    });
+    await expect(page.getByLabel('Depart')).not.toHaveValue('2020-01-01');
+    await expect(page.getByRole('heading', { name: 'Available Flights' })).toHaveCount(0);
+  });
+
   test('Date controls reject past departures and invalid return order', async ({ page }) => {
     await page.goto('/');
 

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,8 +1,17 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitForSearchReady(page: Page) {
+  await expect(page.locator('[data-search-ready="true"]')).toBeVisible();
+}
+
+async function openSearchPage(page: Page, url = '/') {
+  await page.goto(url);
+  await waitForSearchReady(page);
+}
 
 test.describe('Flight search', () => {
   test('Default route and date produce an available flight', async ({ page }) => {
-    await page.goto('/');
+    await openSearchPage(page);
 
     const departureDate = await page.locator('#depart').inputValue();
     expect(departureDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
@@ -16,12 +25,12 @@ test.describe('Flight search', () => {
   });
 
   test('Search criteria and results survive a refresh', async ({ page }) => {
-    await page.goto('/');
+    await openSearchPage(page);
 
-    await page.getByLabel('From').selectOption({ label: 'New York, USA' });
-    await expect(page.getByLabel('To')).toHaveValue('London, UK');
-    const departureDate = await page.getByLabel('Depart').inputValue();
-    const returnDate = await page.getByLabel('Return').inputValue();
+    await page.getByLabel('From', { exact: true }).selectOption({ label: 'New York, USA' });
+    await expect(page.getByLabel('To', { exact: true })).toHaveValue('London, UK');
+    const departureDate = await page.getByLabel('Depart', { exact: true }).inputValue();
+    const returnDate = await page.getByLabel('Return', { exact: true }).inputValue();
 
     await page.getByRole('button', { name: 'Find your trip' }).click();
     await expect(page.getByRole('heading', { name: 'Available Flights' })).toBeVisible();
@@ -44,20 +53,21 @@ test.describe('Flight search', () => {
     });
 
     await page.reload();
+    await waitForSearchReady(page);
 
-    await expect(page.getByLabel('From')).toHaveValue('New York, USA');
-    await expect(page.getByLabel('To')).toHaveValue('London, UK');
-    await expect(page.getByLabel('Depart')).toHaveValue(departureDate);
-    await expect(page.getByLabel('Return')).toHaveValue(returnDate);
+    await expect(page.getByLabel('From', { exact: true })).toHaveValue('New York, USA');
+    await expect(page.getByLabel('To', { exact: true })).toHaveValue('London, UK');
+    await expect(page.getByLabel('Depart', { exact: true })).toHaveValue(departureDate);
+    await expect(page.getByLabel('Return', { exact: true })).toHaveValue(returnDate);
     await expect(page.getByLabel('Round Trip')).toBeChecked();
     await expect(page.getByRole('heading', { name: 'Available Flights' })).toBeVisible();
   });
 
   test('A round trip without an optional return date survives a refresh', async ({ page }) => {
-    await page.goto('/');
+    await openSearchPage(page);
 
-    const departureDate = await page.getByLabel('Depart').inputValue();
-    await page.getByLabel('Return').fill('');
+    const departureDate = await page.getByLabel('Depart', { exact: true }).inputValue();
+    await page.getByLabel('Return', { exact: true }).fill('');
     await page.getByRole('button', { name: 'Find your trip' }).click();
     await expect(page.getByRole('heading', { name: 'Available Flights' })).toBeVisible();
 
@@ -75,34 +85,36 @@ test.describe('Flight search', () => {
     });
 
     await page.reload();
+    await waitForSearchReady(page);
 
-    await expect(page.getByLabel('Depart')).toHaveValue(departureDate);
-    await expect(page.getByLabel('Return')).toHaveValue('');
+    await expect(page.getByLabel('Depart', { exact: true })).toHaveValue(departureDate);
+    await expect(page.getByLabel('Return', { exact: true })).toHaveValue('');
     await expect(page.getByLabel('Round Trip')).toBeChecked();
     await expect(page.getByRole('heading', { name: 'Available Flights' })).toBeVisible();
   });
 
   test('Invalid shared criteria fall back to valid defaults', async ({ page }) => {
-    await page.goto(
+    await openSearchPage(
+      page,
       '/?from=Seattle%2C+USA&to=London%2C+UK&depart=2020-01-01&return=2020-01-08&trip=round-trip'
     );
 
     await expect.poll(async () => ({
-      from: await page.getByLabel('From').inputValue(),
-      to: await page.getByLabel('To').inputValue(),
+      from: await page.getByLabel('From', { exact: true }).inputValue(),
+      to: await page.getByLabel('To', { exact: true }).inputValue(),
     })).not.toEqual({
       from: 'Seattle, USA',
       to: 'London, UK',
     });
-    await expect(page.getByLabel('Depart')).not.toHaveValue('2020-01-01');
+    await expect(page.getByLabel('Depart', { exact: true })).not.toHaveValue('2020-01-01');
     await expect(page.getByRole('heading', { name: 'Available Flights' })).toHaveCount(0);
   });
 
   test('Date controls reject past departures and invalid return order', async ({ page }) => {
-    await page.goto('/');
+    await openSearchPage(page);
 
-    const departure = page.getByLabel('Depart');
-    const returnDate = page.getByLabel('Return');
+    const departure = page.getByLabel('Depart', { exact: true });
+    const returnDate = page.getByLabel('Return', { exact: true });
     const form = page.locator('form');
     const today = new Date().toISOString().slice(0, 10);
     const latest = new Date(`${today}T00:00:00.000Z`);
@@ -176,9 +188,9 @@ test.describe('Flight search', () => {
   });
 
   test('No exact flight offers a nearby operating date that can be searched', async ({ page }) => {
-    await page.goto('/');
+    await openSearchPage(page);
 
-    const departure = page.getByLabel('Depart');
+    const departure = page.getByLabel('Depart', { exact: true });
     const exactOperatingDate = await departure.inputValue();
     const noServiceDate = new Date(`${exactOperatingDate}T00:00:00.000Z`);
     noServiceDate.setUTCDate(noServiceDate.getUTCDate() + 1);

--- a/lib/flightSearchUrl.ts
+++ b/lib/flightSearchUrl.ts
@@ -1,0 +1,117 @@
+import type { FlightRoute } from '@/lib/flightSearch';
+
+export type FlightSearchTripType = 'one-way' | 'round-trip';
+
+export interface FlightSearchCriteria {
+    from: string;
+    to: string;
+    departureDate: string;
+    returnDate: string;
+    tripType: FlightSearchTripType;
+}
+
+export type FlightSearchParamRecord = Record<
+    string,
+    string | string[] | undefined
+>;
+
+interface BookingWindow {
+    earliestDate: string;
+    latestDate: string;
+}
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function singleParam(
+    params: FlightSearchParamRecord,
+    name: string,
+): string | undefined {
+    const value = params[name];
+    return typeof value === 'string' ? value : undefined;
+}
+
+function isIsoDate(value: string | undefined): value is string {
+    if (!value || !ISO_DATE_PATTERN.test(value)) return false;
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    return !Number.isNaN(parsed.getTime())
+        && parsed.toISOString().slice(0, 10) === value;
+}
+
+export function parseFlightSearchParams(
+    params: FlightSearchParamRecord,
+    routes: FlightRoute[],
+    bookingWindow: BookingWindow,
+): FlightSearchCriteria | undefined {
+    if (['from', 'to', 'depart', 'return', 'trip'].some(
+        (name) => Array.isArray(params[name])
+    )) {
+        return undefined;
+    }
+
+    const from = singleParam(params, 'from');
+    const to = singleParam(params, 'to');
+    const departureDate = singleParam(params, 'depart') ?? '';
+    const returnDate = singleParam(params, 'return') ?? '';
+    const tripType = singleParam(params, 'trip');
+
+    if (
+        !from
+        || !to
+        || (tripType !== 'one-way' && tripType !== 'round-trip')
+        || !routes.some((route) => route.from === from && route.to === to)
+        || (departureDate !== '' && (
+            !isIsoDate(departureDate)
+            || departureDate < bookingWindow.earliestDate
+            || departureDate > bookingWindow.latestDate
+        ))
+    ) {
+        return undefined;
+    }
+
+    if (tripType === 'one-way') {
+        return {
+            from,
+            to,
+            departureDate,
+            returnDate: '',
+            tripType,
+        };
+    }
+
+    if (
+        (returnDate !== '' && !isIsoDate(returnDate))
+        || (returnDate !== '' && departureDate === '')
+        || (returnDate !== '' && returnDate < departureDate)
+        || (returnDate !== '' && returnDate > bookingWindow.latestDate)
+    ) {
+        return undefined;
+    }
+
+    return {
+        from,
+        to,
+        departureDate,
+        returnDate,
+        tripType,
+    };
+}
+
+export function buildFlightSearchUrl(
+    criteria: FlightSearchCriteria,
+    pathname: string,
+): string {
+    const params = new URLSearchParams({
+        from: criteria.from,
+        to: criteria.to,
+    });
+
+    if (criteria.departureDate) {
+        params.set('depart', criteria.departureDate);
+    }
+    if (criteria.tripType === 'round-trip' && criteria.returnDate) {
+        params.set('return', criteria.returnDate);
+    }
+    params.set('trip', criteria.tripType);
+
+    return `${pathname}?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary

- write route, trip type, and optional travel dates into the URL only after the current search succeeds
- validate shared criteria against known routes, canonical ISO dates, booking-window limits, and date ordering before restoring them
- automatically rerun valid shared searches on refresh while safely falling back for invalid links
- preserve valid round trips without returns and route-only searches with no dates, using canonical URLs that omit empty optional parameters
- update P1.1 roadmap progress and add parser, component, and end-to-end regression coverage

## Why

This completes the next thin P1.1 vertical slice and satisfies the acceptance criterion that refreshing or sharing a results URL preserves the search without allowing malformed or impossible criteria to enter the form.

## Validation

- Jest: 53 suites, 401 tests passed, including database-backed and subprocess suites
- TypeScript: passed
- ESLint: passed with 8 known pre-existing warnings
- independent production build and standalone environment sanitization: passed
- Docker Compose runtime and homepage HTTP 200: passed
- Playwright search flow: 6/6 passed
- responsive UI review at phone, tablet, and desktop widths: approved
- independent verifier and final code review: approved
